### PR TITLE
Fix crash when price API returns None

### DIFF
--- a/django/variable_income_assets/integrations/handlers.py
+++ b/django/variable_income_assets/integrations/handlers.py
@@ -72,6 +72,9 @@ async def update_prices() -> Exception | None:
         )
         for data in result:
             for code, price in data["prices"].items():
+                if price is None:
+                    print(f"Skipping {code}: price is None")
+                    continue
                 asset_metadata = assets_metadata_map[
                     "-".join((code, data["type"], data["currency"]))
                 ]


### PR DESCRIPTION
## Summary
- Skip assets with `None` prices during metadata update instead of converting `None` to the string `"None"`, which fails Django's `DecimalField` validation
- Adds a print statement to log which asset code is being skipped

## Context
The cron job was failing with:
```
ValidationError(['"None" value must be a decimal number.'])
```
One of the price providers (BrApi, TwelveData, or CoinMarketCap) occasionally returns `null` for a price. `str(None)` → `"None"` was then passed to `abulk_update`, crashing the entire price update.

## Test plan
- [ ] Deploy and monitor next cron run for `Skipping <code>: price is None` log output
- [ ] Verify remaining assets still get their prices updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)