### PR TITLE
Persist FIRE planning inputs

### DIFF
--- a/django/authentication/serializers.py
+++ b/django/authentication/serializers.py
@@ -118,7 +118,27 @@ class PlanningPreferencesSerializer(serializers.Serializer):
         required=False,
     )
     show_galeno = serializers.BooleanField(required=False, default=False)
-    show_age_in_bonds = serializers.BooleanField(required=False, default=False)
+    show_age_in_bonds = serializers.BooleanField(required=False)
+
+    class FirePreferencesSerializer(serializers.Serializer):
+        withdrawal_rate = serializers.FloatField(
+            required=False,
+            min_value=2,
+            max_value=6,
+        )
+        target_years = serializers.IntegerField(
+            required=False,
+            min_value=20,
+            max_value=80,
+        )
+        monthly_expenses_override = serializers.FloatField(
+            required=False,
+            allow_null=True,
+            min_value=0,
+        )
+        exclude_ifix_from_sim = serializers.BooleanField(required=False)
+
+    fire = FirePreferencesSerializer(required=False)
 
 
 class UserSerializer(serializers.ModelSerializer):
@@ -224,10 +244,20 @@ class UserSerializer(serializers.ModelSerializer):
             )
 
         if "planning_preferences" in validated_data:
+            incoming_preferences = validated_data["planning_preferences"]
+            current_preferences = instance.planning_preferences or {}
             merged = {
-                **(instance.planning_preferences or {}),
-                **validated_data["planning_preferences"],
+                **current_preferences,
+                **incoming_preferences,
             }
+            if "fire" in incoming_preferences:
+                current_fire = current_preferences.get("fire") or {}
+                if not isinstance(current_fire, dict):
+                    current_fire = {}
+                merged["fire"] = {
+                    **current_fire,
+                    **incoming_preferences["fire"],
+                }
             if merged.get("show_galeno") and merged.get("selected_method") not in (
                 "fire",
                 "constant_withdrawal",
@@ -237,7 +267,10 @@ class UserSerializer(serializers.ModelSerializer):
                 raise serializers.ValidationError(
                     {
                         "planning_preferences": {
-                            "show_galeno": "Galeno só pode ser ativado com FIRE, Retirada constante, Retirada 1/N ou VPW."
+                            "show_galeno": (
+                                "Galeno só pode ser ativado com FIRE, Retirada constante, "
+                                "Retirada 1/N ou VPW."
+                            )
                         }
                     }
                 )
@@ -256,7 +289,10 @@ class UserSerializer(serializers.ModelSerializer):
                 raise serializers.ValidationError(
                     {
                         "planning_preferences": {
-                            "show_age_in_bonds": "Idade em RF só pode ser ativado com Regra dos X% ou Retirada constante."
+                            "show_age_in_bonds": (
+                                "Idade em RF só pode ser ativado com Regra dos X% ou "
+                                "Retirada constante."
+                            )
                         }
                     }
                 )
@@ -264,7 +300,9 @@ class UserSerializer(serializers.ModelSerializer):
                 raise serializers.ValidationError(
                     {
                         "planning_preferences": {
-                            "show_age_in_bonds": "Idade em RF e Galeno não podem ser ativados ao mesmo tempo."
+                            "show_age_in_bonds": (
+                                "Idade em RF e Galeno não podem ser ativados ao mesmo tempo."
+                            )
                         }
                     }
                 )

--- a/django/authentication/tests/test__user__views.py
+++ b/django/authentication/tests/test__user__views.py
@@ -597,6 +597,71 @@ def test__partial_update__planning_preferences__one_over_n_with_galeno(client, u
     assert user.planning_preferences["show_galeno"] is True
 
 
+def test__partial_update__planning_preferences__fire_inputs(client, user):
+    # GIVEN
+    data = {
+        "planning_preferences": {
+            "fire": {
+                "withdrawal_rate": 3.5,
+                "target_years": 45,
+                "monthly_expenses_override": 12500,
+                "exclude_ifix_from_sim": True,
+            }
+        }
+    }
+
+    # WHEN
+    response = client.patch(f"{URL}/{user.pk}", data=data)
+
+    # THEN
+    assert response.status_code == HTTP_200_OK
+    user.refresh_from_db()
+    assert user.planning_preferences["fire"] == {
+        "withdrawal_rate": 3.5,
+        "target_years": 45,
+        "monthly_expenses_override": 12500.0,
+        "exclude_ifix_from_sim": True,
+    }
+
+
+def test__partial_update__planning_preferences__merges_fire_inputs(client, user):
+    # GIVEN
+    user.planning_preferences = {
+        "selected_method": "fire",
+        "fire": {
+            "withdrawal_rate": 3.5,
+            "target_years": 45,
+            "monthly_expenses_override": 12500,
+            "exclude_ifix_from_sim": False,
+        },
+    }
+    user.save()
+    data = {
+        "planning_preferences": {
+            "fire": {
+                "monthly_expenses_override": None,
+                "exclude_ifix_from_sim": True,
+            }
+        }
+    }
+
+    # WHEN
+    response = client.patch(f"{URL}/{user.pk}", data=data)
+
+    # THEN
+    assert response.status_code == HTTP_200_OK
+    user.refresh_from_db()
+    assert user.planning_preferences == {
+        "selected_method": "fire",
+        "fire": {
+            "withdrawal_rate": 3.5,
+            "target_years": 45,
+            "monthly_expenses_override": None,
+            "exclude_ifix_from_sim": True,
+        },
+    }
+
+
 def test__partial_update__date_of_birth(client, user):
     # GIVEN
     data = {"date_of_birth": "15/06/1990"}

--- a/django/variable_income_assets/management/commands/irpf_report.py
+++ b/django/variable_income_assets/management/commands/irpf_report.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from django.core.management.base import BaseCommand
+
+from variable_income_assets.scripts import print_irpf_infos
+
+if TYPE_CHECKING:  # pragma: no cover
+    from django.core.management.base import CommandParser
+
+
+
+
+class Command(BaseCommand):  # pragma: no cover
+    def add_arguments(self, parser: CommandParser) -> None:
+        parser.add_argument("--user-id", type=int, required=True)
+
+    def handle(self, **options):
+        print_irpf_infos(options["user_id"], debug=options["verbosity"])

--- a/django/variable_income_assets/models/managers/write.py
+++ b/django/variable_income_assets/models/managers/write.py
@@ -8,7 +8,7 @@ from django.db.models.functions import Coalesce, Concat, Greatest, TruncMonth, T
 
 from shared.managers_utils import GenericDateFilters
 
-from ...choices import AssetTypes, PassiveIncomeEventTypes
+from ...choices import AssetTypes, PassiveIncomeEventTypes, PassiveIncomeTypes
 from .expressions import GenericQuerySetExpressions
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -208,7 +208,13 @@ class AssetQuerySet(QuerySet):
         ).annotate(
             transactions_balance=self.expressions.get_quantity_balance(extra_filters),
             avg_price=self.expressions.get_avg_price(extra_filters),
-            total_invested=F("normalized_avg_price") * F("transactions_balance"),
+            normalized_total_invested=F("normalized_avg_price") * F("transactions_balance"),
+            total_invested=F("avg_price") * F("transactions_balance"),
+            avg_current_currency_conversion_rate=Coalesce(
+                self.expressions.get_normalized_total_bought(extra_filters)
+                / Greatest(self.expressions.get_total_bought(extra_filters), Value(Decimal("1.0"))),
+                Decimal(),
+            ),
         )
 
     def filter_opened_after(self, operation_date: date) -> Self:
@@ -220,7 +226,7 @@ class AssetQuerySet(QuerySet):
         )
 
     def annotate_credited_incomes_at_given_year(
-        self, year: int, incomes_type: PassiveIncomeEventTypes
+        self, year: int, incomes_type: PassiveIncomeTypes
     ) -> Self:
         return self.annotate(
             normalized_credited_incomes_total=Coalesce(

--- a/django/variable_income_assets/scripts.py
+++ b/django/variable_income_assets/scripts.py
@@ -49,48 +49,113 @@ def _print_assets_portfolio(qs: AssetQuerySet[Asset], year: int) -> None:
         qs.annotate_irpf_infos(year=year)
         .filter(transactions_balance__gt=0)
         .values(
-            "code", "currency", "transactions_balance", "avg_price", "total_invested", "description"
+            "code",
+            "currency",
+            "transactions_balance",
+            "avg_price",
+            "total_invested",
+            "description",
+            "normalized_total_invested",
+            "avg_current_currency_conversion_rate",
         ),
         start=1,
     ):
-        # Preço médio sempre na moeda original e total em reais
-        # TODO: adicionar dolar médio
-        currency_symbol = Currencies.get_choice(asset["currency"]).symbol
+        # Examplo de descrição na receita pra dolar:
+        # 91,166711130 ACOES (EWBC) // EAST WEST BANCORP, INC. //
+        # COM CUSTO DE AQUISICAO DE US$ 3.962,24, SENDO O DOLAR MEDIO DE 4,9728,
+        # CUSTODIADOS PELA CORRETORA VEST
+        currency = Currencies.get_choice(asset["currency"])
         results.append(
             f"{i}. {asset['code']} - {asset['description']}"
             if asset["description"]
             else f"{i}. {asset['code']}"
         )
         results.append(f"\tQuantidade: {asset['transactions_balance']:n}")
-        results.append(f"\tPreço médio: {currency_symbol} {asset['avg_price']:n}")
-        results.append(f"\tTotal: R$ {asset['total_invested']:n}\n")
+        results.append(f"\tPreço médio: {currency.symbol} {asset['avg_price']:n}")
+        results.append(
+            f"\tTotal: R$ {asset['normalized_total_invested']:n}\n"
+            if currency.value == Currencies.real
+            else (
+                f"\tTotal: R$ {asset['normalized_total_invested']:n} "
+                f"| {currency.symbol} {asset['total_invested']:n}\n"
+            )
+        )
+        if currency.value == Currencies.dollar:
+            results.append(f"\tDólar médio: R$ {asset['avg_current_currency_conversion_rate']:n}\n")
 
     if results:
         print("------------ ATIVOS (seção 'Bens e direitos') ------------\n\n")
         print(*results, sep="\n")
 
 
-def _print_credited_incomes(qs: AssetQuerySet[Asset], year: int) -> None:
-    mapping = {
-        PassiveIncomeTypes.dividend: (
-            "'Rendimentos isentos e não tributáveis', opção '09 - Lucros e dividendos recebidos'"
-        ),
-        PassiveIncomeTypes.income: "?",
-    }
-    for value, label in PassiveIncomeTypes:
-        if value == PassiveIncomeTypes.jcp:
-            continue
-        results = []
-        for i, a in enumerate(
-            qs.annotate_credited_incomes_at_given_year(year=year, incomes_type=value)
-            .filter(normalized_credited_incomes_total__gt=0)
-            .values("code", "normalized_credited_incomes_total"),
-            start=1,
-        ):
-            results.append(f"{i}. {a['code']} -> R$ {a['normalized_credited_incomes_total']:n}")
-        if results:
-            print(f"\n\n------------ {label.upper()} (seção {mapping[value]}) ------------\n\n")
-            print(*results, sep="\n")
+def _print_credited_incomes(qs: AssetQuerySet[Asset], year: int, debug: int = 1) -> None:
+    dividend_section = (
+        "'Rendimentos isentos e não tributáveis', opção '09 - Lucros e dividendos recebidos'"
+    )
+    results = []
+    for i, a in enumerate(
+        qs.annotate_credited_incomes_at_given_year(
+            year=year, incomes_type=PassiveIncomeTypes.dividend
+        )
+        .filter(normalized_credited_incomes_total__gt=0)
+        .values("code", "normalized_credited_incomes_total"),
+        start=1,
+    ):
+        results.append(f"{i}. {a['code']} -> R$ {a['normalized_credited_incomes_total']:n}")
+    if results:
+        print(f"\n\n------------ DIVIDENDO (seção {dividend_section}) ------------\n\n")
+        print(*results, sep="\n")
+
+    _print_credited_reimbursements(qs=qs, year=year, debug=debug)
+    _print_credited_incomes_per_stock(qs=qs, year=year)
+
+
+def _print_credited_reimbursements(
+    qs: AssetQuerySet[Asset], year: int, debug: int
+) -> None:
+    B3_CNPJ = "09.346.601/0001-25"
+    section = "'Outros rendimentos isentos'"
+
+    reimbursement_by_code: dict[str, Decimal] = {}
+    for a in (
+        qs.annotate_credited_incomes_at_given_year(
+            year=year, incomes_type=PassiveIncomeTypes.reimbursement
+        )
+        .filter(normalized_credited_incomes_total__gt=0)
+        .values("code", "normalized_credited_incomes_total")
+    ):
+        reimbursement_by_code[a["code"]] = a["normalized_credited_incomes_total"]
+
+    if not reimbursement_by_code:
+        return
+
+    reimbursement_total = sum(reimbursement_by_code.values())
+    print(f"\n\n------------ REEMBOLSO (seção {section}) ------------\n\n")
+    print(f"1. B3 -> R$ {reimbursement_total:n}")
+    print(f"   CNPJ: {B3_CNPJ}")
+    if debug > 1:
+        print("\n\n")
+        for code in sorted(reimbursement_by_code):
+            print(f"   {code}: R$ {reimbursement_by_code[code]:n}")
+
+
+def _print_credited_incomes_per_stock(qs: AssetQuerySet[Asset], year: int) -> None:
+    section = "'Outros rendimentos isentos'"
+
+    results = []
+    for i, a in enumerate(
+        qs.annotate_credited_incomes_at_given_year(
+            year=year, incomes_type=PassiveIncomeTypes.income
+        )
+        .filter(normalized_credited_incomes_total__gt=0)
+        .values("code", "normalized_credited_incomes_total"),
+        start=1,
+    ):
+        results.append(f"{i}. {a['code']} -> R$ {a['normalized_credited_incomes_total']:n}")
+
+    if results:
+        print(f"\n\n------------ RENDIMENTO (seção {section}) ------------\n\n")
+        print(*results, sep="\n")
 
 
 def _print_credited_jcps(qs: AssetQuerySet[Asset], year: int) -> None:
@@ -320,6 +385,8 @@ def _print_stocks_not_elegible_for_taxation(user_pk: int, year: int, debug: bool
                     )
             else:
                 asset_losses += roi
+                if debug > 1:
+                    results.append(f"\t\t\t{t.asset_code} -> roi = R$ {roi:n}")
 
         if debug > 1:
             results.append("")
@@ -494,7 +561,7 @@ def print_irpf_infos(
 
     year = year if year is not None else timezone.localtime().year - 1
     _print_assets_portfolio(qs=qs, year=year)
-    _print_credited_incomes(qs=qs, year=year)
+    _print_credited_incomes(qs=qs, year=year, debug=debug)
 
     print("\n\n------------ RENDIMENTOS SUJEITOS A TRIBUTAÇÃO ------------\n")
     _print_credited_jcps(qs=qs, year=year)
@@ -631,7 +698,9 @@ def generate_fire_returns_ts(
 
     # Reverse-engineered from B3's index statistics pages; this is not a stable
     # public API, so keep the generated TS checked in and rerun intentionally.
-    B3_INDEX_URL = "https://sistemaswebb3-listados.b3.com.br/indexStatisticsProxy/IndexCall/GetPortfolioDay"
+    B3_INDEX_URL = (
+        "https://sistemaswebb3-listados.b3.com.br/indexStatisticsProxy/IndexCall/GetPortfolioDay"
+    )
     BCB_CDI_URL = (
         "https://api.bcb.gov.br/dados/serie/bcdata.sgs.4391/dados"
         f"?formato=json&dataInicial=01/01/{start_year}&dataFinal=31/12/{{end}}"
@@ -687,9 +756,7 @@ def generate_fire_returns_ts(
 
     def iter_months(first_year: int, last_year: int) -> list[tuple[int, int]]:
         return [
-            (year, month)
-            for year in range(first_year, last_year + 1)
-            for month in range(1, 13)
+            (year, month) for year in range(first_year, last_year + 1) for month in range(1, 13)
         ]
 
     def b3_index_url(index: str, year: int) -> str:
@@ -855,12 +922,8 @@ def generate_fire_returns_ts(
     if not common_months:
         raise RuntimeError("No overlapping complete months between IBOV, CDI, and IPCA.")
 
-    real_rm_monthly = [
-        (1 + monthly_ibov[m]) / (1 + ipca_by_month[m]) - 1 for m in common_months
-    ]
-    real_rf_monthly = [
-        (1 + cdi_by_month[m]) / (1 + ipca_by_month[m]) - 1 for m in common_months
-    ]
+    real_rm_monthly = [(1 + monthly_ibov[m]) / (1 + ipca_by_month[m]) - 1 for m in common_months]
+    real_rf_monthly = [(1 + cdi_by_month[m]) / (1 + ipca_by_month[m]) - 1 for m in common_months]
 
     print(f"Downloading B3 IFIX from {B3_INDEX_URL} ...")
     ifix_start_year = 2011
@@ -899,13 +962,9 @@ def generate_fire_returns_ts(
         )
     real_ifix = [(1 + annual_ifix[y]) / (1 + annual_ipca[y]) - 1 for y in ifix_years]
     ifix_months = sorted(
-        m
-        for m in set(monthly_ifix) & set(ipca_by_month)
-        if ifix_days_by_month[m] > 0
+        m for m in set(monthly_ifix) & set(ipca_by_month) if ifix_days_by_month[m] > 0
     )
-    real_ifix_monthly = [
-        (1 + monthly_ifix[m]) / (1 + ipca_by_month[m]) - 1 for m in ifix_months
-    ]
+    real_ifix_monthly = [(1 + monthly_ifix[m]) / (1 + ipca_by_month[m]) - 1 for m in ifix_months]
 
     rm_values = ", ".join(f"{v:.6f}" for v in real_rm)
     rf_values = ", ".join(f"{v:.6f}" for v in real_rf)

--- a/django/variable_income_assets/tests/test_queries.py
+++ b/django/variable_income_assets/tests/test_queries.py
@@ -45,7 +45,7 @@ def test__asset__irp_infos(stock_usa_asset):
             normalize=True,
             extra_filters=Q(operation_date__year__lte=year),
         )
-    ) == convert_and_quantitize(asset["total_invested"])
+    ) == convert_and_quantitize(asset["normalized_total_invested"])
 
 
 @pytest.mark.usefixtures("irpf_assets_data")
@@ -100,8 +100,8 @@ def test__asset__using_dollar_as(stock_usa_asset):
 
     # THEN
     assert convert_and_quantitize(asset["avg_price"]) == convert_and_quantitize(asset2["avg_price"])
-    assert convert_and_quantitize(asset["total_invested"] * 2) == convert_and_quantitize(
-        asset2["total_invested"]
+    assert convert_and_quantitize(asset["normalized_total_invested"] * 2) == convert_and_quantitize(
+        asset2["normalized_total_invested"]
     )
 
 

--- a/react/src/pages/private/Home/ConstantDollarAgeInBondsIndicator.tsx
+++ b/react/src/pages/private/Home/ConstantDollarAgeInBondsIndicator.tsx
@@ -546,6 +546,11 @@ const ConstantDollarAgeInBondsIndicator = ({
   onMonthlySavingsChange,
   onMonthlySavingsReset,
   isMonthlySavingsOverridden = false,
+  simulatedExpenses: simulatedExpensesProp,
+  onSimulatedExpensesChange,
+  excludeIfixFromSim: excludeIfixFromSimProp,
+  onExcludeIfixFromSimChange,
+  onProgressClick,
   compact = false,
   hideLabel = false,
 }: {
@@ -566,6 +571,11 @@ const ConstantDollarAgeInBondsIndicator = ({
   onMonthlySavingsChange?: (value: number) => void;
   onMonthlySavingsReset?: () => void;
   isMonthlySavingsOverridden?: boolean;
+  simulatedExpenses?: number | null;
+  onSimulatedExpensesChange?: (value: number | null) => void;
+  excludeIfixFromSim?: boolean;
+  onExcludeIfixFromSimChange?: (value: boolean) => void;
+  onProgressClick?: () => void;
   compact?: boolean;
   hideLabel?: boolean;
 }) => {
@@ -574,7 +584,17 @@ const ConstantDollarAgeInBondsIndicator = ({
   const [visibleScenarios, setVisibleScenarios] = useState<
     ("otimista" | "mediana" | "pessimista")[]
   >(["otimista", "mediana", "pessimista"]);
-  const [simulatedExpenses, setSimulatedExpenses] = useState<number | null>(null);
+  const [localSimulatedExpenses, setLocalSimulatedExpenses] = useState<
+    number | null
+  >(null);
+  const simulatedExpenses =
+    simulatedExpensesProp !== undefined
+      ? simulatedExpensesProp
+      : localSimulatedExpenses;
+  const setSimulatedExpenses = (value: number | null) => {
+    if (onSimulatedExpensesChange) onSimulatedExpensesChange(value);
+    else setLocalSimulatedExpenses(value);
+  };
   const effectiveMonthlyExpenses = simulatedExpenses ?? avgExpenses;
   const showOtimista = visibleScenarios.includes("otimista");
   const showMediana = visibleScenarios.includes("mediana");
@@ -587,7 +607,13 @@ const ConstantDollarAgeInBondsIndicator = ({
   // the buildAgeInBondsWeightsAt comment above for how it propagates through
   // the glide path (per-year `weights.ifix = 0` without redistributing to
   // equity, weights sum to <1, missing fraction earns 0% real).
-  const [excludeIfixFromSim, setExcludeIfixFromSim] = useState(false);
+  const [localExcludeIfixFromSim, setLocalExcludeIfixFromSim] = useState(false);
+  const excludeIfixFromSim =
+    excludeIfixFromSimProp ?? localExcludeIfixFromSim;
+  const setExcludeIfixFromSim = (value: boolean) => {
+    if (onExcludeIfixFromSimChange) onExcludeIfixFromSimChange(value);
+    else setLocalExcludeIfixFromSim(value);
+  };
 
   const annualExpenses = effectiveMonthlyExpenses * 12;
   const annualWithdrawal = effectivePatrimony * (withdrawalRate / 100);
@@ -742,7 +768,22 @@ const ConstantDollarAgeInBondsIndicator = ({
   return (
     <Stack gap={0.5}>
       <Tooltip title={tooltipTitle} arrow placement="top">
-        <div style={{ position: "relative" }}>
+        <div
+          role={onProgressClick ? "link" : undefined}
+          tabIndex={onProgressClick ? 0 : undefined}
+          onClick={onProgressClick}
+          onKeyDown={(event) => {
+            if (!onProgressClick) return;
+            if (event.key === "Enter" || event.key === " ") {
+              event.preventDefault();
+              onProgressClick();
+            }
+          }}
+          style={{
+            position: "relative",
+            cursor: onProgressClick ? "pointer" : undefined,
+          }}
+        >
           <ProgressBar
             variant="determinate"
             value={Math.min(fireProgress, 100)}
@@ -793,6 +834,15 @@ const ConstantDollarAgeInBondsIndicator = ({
       <Stack direction="row" alignItems="center" gap={2} flexWrap="wrap">
         <Text size={FontSizes.EXTRA_SMALL} color={Colors.neutral400}>
           {(() => {
+            const compactTargetTail =
+              fireProgress < 100 &&
+              annualSavings > 0 &&
+              accumulation.medianYearsToTarget !== null
+                ? ` (~${accumulation.medianYearsToTarget}a no ritmo atual)`
+                : "";
+            if (compact) {
+              return `Meta: ${hideValues ? "***" : formatCurrency(fireTarget)}${compactTargetTail}`;
+            }
             const gap = monthlyWithdrawal - effectiveMonthlyExpenses;
             const gapFormatted = hideValues ? "***" : formatCurrency(Math.abs(gap));
             const sign = gap >= 0 ? "sobram" : "faltam";
@@ -827,52 +877,50 @@ const ConstantDollarAgeInBondsIndicator = ({
           )}
         </Text>
       </Stack>
-      <Stack direction="row" alignItems="center" gap={2} flexWrap="wrap">
-        <Text size={FontSizes.EXTRA_SMALL} color={Colors.neutral400}>
-          Taxa: {withdrawalRate}% a.a.
-        </Text>
-        <Slider
-          value={withdrawalRate}
-          onChange={(_, value) => onWithdrawalRateChange(value as number)}
-          min={2}
-          max={6}
-          step={0.5}
-          marks
-          size="medium"
-          sx={sliderSx}
-        />
-        {!compact && (
-          <>
-            <Text size={FontSizes.EXTRA_SMALL} color={Colors.neutral400}>
-              Horizonte: {targetYears} anos
-            </Text>
-            <Slider
-              value={targetYears}
-              onChange={(_, value) => onTargetYearsChange(value as number)}
-              min={20}
-              max={80}
-              step={5}
-              marks
-              size="medium"
-              sx={sliderSx}
-            />
-            <PatrimonySimulator
-              value={effectivePatrimony}
-              onChange={setSimulatedPatrimony}
-              onReset={() => setSimulatedPatrimony(null)}
-              patrimonyTotal={patrimonyTotal}
-              showReset={simulatedPatrimony !== null}
-            />
-            <ExpenseSimulator
-              value={effectiveMonthlyExpenses}
-              onChange={setSimulatedExpenses}
-              onReset={() => setSimulatedExpenses(null)}
-              avgMonthlyExpenses={avgExpenses}
-              showReset={simulatedExpenses !== null}
-            />
-          </>
-        )}
-      </Stack>
+      {!compact && (
+        <Stack direction="row" alignItems="center" gap={2} flexWrap="wrap">
+          <Text size={FontSizes.EXTRA_SMALL} color={Colors.neutral400}>
+            Taxa: {withdrawalRate}% a.a.
+          </Text>
+          <Slider
+            value={withdrawalRate}
+            onChange={(_, value) => onWithdrawalRateChange(value as number)}
+            min={2}
+            max={6}
+            step={0.5}
+            marks
+            size="medium"
+            sx={sliderSx}
+          />
+          <Text size={FontSizes.EXTRA_SMALL} color={Colors.neutral400}>
+            Horizonte: {targetYears} anos
+          </Text>
+          <Slider
+            value={targetYears}
+            onChange={(_, value) => onTargetYearsChange(value as number)}
+            min={20}
+            max={80}
+            step={5}
+            marks
+            size="medium"
+            sx={sliderSx}
+          />
+          <PatrimonySimulator
+            value={effectivePatrimony}
+            onChange={setSimulatedPatrimony}
+            onReset={() => setSimulatedPatrimony(null)}
+            patrimonyTotal={patrimonyTotal}
+            showReset={simulatedPatrimony !== null}
+          />
+          <ExpenseSimulator
+            value={effectiveMonthlyExpenses}
+            onChange={setSimulatedExpenses}
+            onReset={() => setSimulatedExpenses(null)}
+            avgMonthlyExpenses={avgExpenses}
+            showReset={simulatedExpenses !== null}
+          />
+        </Stack>
+      )}
       {!compact && (
         <Stack direction="row" alignItems="center" gap={2}>
           <Text

--- a/react/src/pages/private/Home/ConstantDollarIndicator.tsx
+++ b/react/src/pages/private/Home/ConstantDollarIndicator.tsx
@@ -209,6 +209,9 @@ const ConstantDollarIndicator = ({
   onSimulatedPatrimonyChange,
   simulatedExpenses: simulatedExpensesProp,
   onSimulatedExpensesChange,
+  excludeIfixFromSim: excludeIfixFromSimProp,
+  onExcludeIfixFromSimChange,
+  onProgressClick,
 }: {
   patrimonyTotal: number;
   avgExpenses: number;
@@ -235,6 +238,9 @@ const ConstantDollarIndicator = ({
   onSimulatedPatrimonyChange?: (value: number | null) => void;
   simulatedExpenses?: number | null;
   onSimulatedExpensesChange?: (value: number | null) => void;
+  excludeIfixFromSim?: boolean;
+  onExcludeIfixFromSimChange?: (value: boolean) => void;
+  onProgressClick?: () => void;
 }) => {
   const { hideValues } = useHideValues();
   const [localSimulatedPatrimony, setLocalSimulatedPatrimony] = useState<
@@ -310,7 +316,13 @@ const ConstantDollarIndicator = ({
   // fraction contributes 0 to per-year portfolio returns, so the IFIX slice
   // earns nothing real (no equity/FI redistribution). Sample window unlocks
   // because ifix=0 falls below MIN_WEIGHT_FOR_RETURN_SERIES.
-  const [excludeIfixFromSim, setExcludeIfixFromSim] = useState(false);
+  const [localExcludeIfixFromSim, setLocalExcludeIfixFromSim] = useState(false);
+  const excludeIfixFromSim =
+    excludeIfixFromSimProp ?? localExcludeIfixFromSim;
+  const setExcludeIfixFromSim = (value: boolean) => {
+    if (onExcludeIfixFromSimChange) onExcludeIfixFromSimChange(value);
+    else setLocalExcludeIfixFromSim(value);
+  };
   const weights = useMemo(
     () => (excludeIfixFromSim ? { ...rawWeights, ifix: 0 } : rawWeights),
     [rawWeights, excludeIfixFromSim],
@@ -444,7 +456,22 @@ const ConstantDollarIndicator = ({
   return (
     <Stack gap={0.5}>
       <Tooltip title={tooltipTitle} arrow placement="top">
-        <div style={{ position: "relative" }}>
+        <div
+          role={onProgressClick ? "link" : undefined}
+          tabIndex={onProgressClick ? 0 : undefined}
+          onClick={onProgressClick}
+          onKeyDown={(event) => {
+            if (!onProgressClick) return;
+            if (event.key === "Enter" || event.key === " ") {
+              event.preventDefault();
+              onProgressClick();
+            }
+          }}
+          style={{
+            position: "relative",
+            cursor: onProgressClick ? "pointer" : undefined,
+          }}
+        >
           <ProgressBar
             variant="determinate"
             value={Math.min(fireProgress, 100)}
@@ -495,6 +522,15 @@ const ConstantDollarIndicator = ({
       <Stack direction="row" alignItems="center" gap={2} flexWrap="wrap">
         <Text size={FontSizes.EXTRA_SMALL} color={Colors.neutral400}>
           {(() => {
+            const compactTargetTail =
+              retirementProgress < 100 &&
+              annualSavings > 0 &&
+              accumulation.medianYearsToTarget !== null
+                ? ` (~${accumulation.medianYearsToTarget}a no ritmo atual)`
+                : "";
+            if (compact) {
+              return `Meta: ${hideValues ? "***" : formatCurrency(fireTarget)}${compactTargetTail}`;
+            }
             const gap = monthlyWithdrawal - effectiveMonthlyExpenses;
             const gapFormatted = hideValues ? "***" : formatCurrency(Math.abs(gap));
             const sign = gap >= 0 ? "sobram" : "faltam";
@@ -515,52 +551,50 @@ const ConstantDollarIndicator = ({
           })()}
         </Text>
       </Stack>
-      <Stack direction="row" alignItems="center" gap={2} flexWrap="wrap">
-        <Text size={FontSizes.EXTRA_SMALL} color={Colors.neutral400}>
-          Taxa: {withdrawalRate}% a.a.
-        </Text>
-        <Slider
-          value={withdrawalRate}
-          onChange={(_, value) => onWithdrawalRateChange(value as number)}
-          min={2}
-          max={6}
-          step={0.5}
-          marks
-          size="medium"
-          sx={sliderSx}
-        />
-        {!compact && (
-          <>
-            <Text size={FontSizes.EXTRA_SMALL} color={Colors.neutral400}>
-              Horizonte: {targetYears} anos
-            </Text>
-            <Slider
-              value={targetYears}
-              onChange={(_, value) => onTargetYearsChange(value as number)}
-              min={20}
-              max={80}
-              step={5}
-              marks
-              size="medium"
-              sx={sliderSx}
-            />
-            <PatrimonySimulator
-              value={effectivePatrimony}
-              onChange={setSimulatedPatrimony}
-              onReset={() => setSimulatedPatrimony(null)}
-              patrimonyTotal={patrimonyTotal}
-              showReset={simulatedPatrimony !== null}
-            />
-            <ExpenseSimulator
-              value={effectiveMonthlyExpenses}
-              onChange={setSimulatedExpenses}
-              onReset={() => setSimulatedExpenses(null)}
-              avgMonthlyExpenses={avgExpenses}
-              showReset={simulatedExpenses !== null}
-            />
-          </>
-        )}
-      </Stack>
+      {!compact && (
+        <Stack direction="row" alignItems="center" gap={2} flexWrap="wrap">
+          <Text size={FontSizes.EXTRA_SMALL} color={Colors.neutral400}>
+            Taxa: {withdrawalRate}% a.a.
+          </Text>
+          <Slider
+            value={withdrawalRate}
+            onChange={(_, value) => onWithdrawalRateChange(value as number)}
+            min={2}
+            max={6}
+            step={0.5}
+            marks
+            size="medium"
+            sx={sliderSx}
+          />
+          <Text size={FontSizes.EXTRA_SMALL} color={Colors.neutral400}>
+            Horizonte: {targetYears} anos
+          </Text>
+          <Slider
+            value={targetYears}
+            onChange={(_, value) => onTargetYearsChange(value as number)}
+            min={20}
+            max={80}
+            step={5}
+            marks
+            size="medium"
+            sx={sliderSx}
+          />
+          <PatrimonySimulator
+            value={effectivePatrimony}
+            onChange={setSimulatedPatrimony}
+            onReset={() => setSimulatedPatrimony(null)}
+            patrimonyTotal={patrimonyTotal}
+            showReset={simulatedPatrimony !== null}
+          />
+          <ExpenseSimulator
+            value={effectiveMonthlyExpenses}
+            onChange={setSimulatedExpenses}
+            onReset={() => setSimulatedExpenses(null)}
+            avgMonthlyExpenses={avgExpenses}
+            showReset={simulatedExpenses !== null}
+          />
+        </Stack>
+      )}
       {!compact && (
         <Stack direction="row" alignItems="center" gap={2}>
           <Text

--- a/react/src/pages/private/Home/Indicators.tsx
+++ b/react/src/pages/private/Home/Indicators.tsx
@@ -4,6 +4,7 @@ import Grid from "@mui/material/Grid";
 import Stack from "@mui/material/Stack";
 import MonetizationOnOutlinedIcon from "@mui/icons-material/MonetizationOnOutlined";
 import SvgIcon from "@mui/material/SvgIcon";
+import { useNavigate } from "react-router-dom";
 
 import { startOfMonth } from "date-fns";
 
@@ -27,7 +28,7 @@ import { useAssetsReports } from "../Assets/Reports/AssetAggregationReports/hook
 import { GroupBy, Kinds } from "../Assets/Reports/types";
 import type { ReportAggregatedByTypeDataItem } from "../Assets/Reports/types";
 import { usePlanningPreferences, useSelectedMethod } from "../Planning/hooks";
-import type { WithdrawalMethodKey } from "../Planning/api";
+import { getFirePlanningPreferences } from "../Planning/api";
 import DividendsOnlyIndicator from "./DividendsOnlyIndicator";
 import ConstantDollarIndicator from "./ConstantDollarIndicator";
 import GalenoIndicator from "./GalenoIndicator";
@@ -38,9 +39,8 @@ import VPWIndicator from "./VPWIndicator";
 
 const Indicators = () => {
   const { hideValues } = useHideValues();
-  const [fireWithdrawalRate, setFireWithdrawalRate] = useState(4);
+  const navigate = useNavigate();
   const [realReturn, setRealReturn] = useState(5);
-  const [targetYears, setTargetYears] = useState(30);
   const [galenoTransferRate, setGalenoTransferRate] = useState(6);
   const [galenoTargetBufferYears, setGalenoTargetBufferYears] = useState(7);
   const [targetDepletionAge, setTargetDepletionAge] = useState(90);
@@ -53,6 +53,7 @@ const Indicators = () => {
   const { selectedMethod } = useSelectedMethod();
   const { data: planningData } = usePlanningPreferences();
   const preferences = planningData?.preferences;
+  const firePreferences = getFirePlanningPreferences(preferences);
   const dateOfBirth = planningData?.dateOfBirth ?? null;
   // Galeno parked while we redesign it as a standalone strategy — see
   // docs/superpowers/plans/2026-04-26-galeno-strategy.md. Re-enable by
@@ -138,6 +139,7 @@ const Indicators = () => {
   // surfaces a hint instead of a bogus projection.
   const monthlySavings =
     (revenuesIndicators?.avg ?? 0) - (expensesIndicators?.avg ?? 0);
+  const openFireStrategy = () => navigate("/planning/fire");
 
   return (
     <Grid container spacing={4}>
@@ -202,15 +204,18 @@ const Indicators = () => {
                     avgExpenses={expensesIndicators?.fire_avg ?? 0}
                     isLoading={isLoading || isExpensesIndicatorsLoading || isReportsLoading}
                     dateOfBirth={dateOfBirth}
-                    withdrawalRate={fireWithdrawalRate}
-                    onWithdrawalRateChange={setFireWithdrawalRate}
-                    targetYears={targetYears}
-                    onTargetYearsChange={setTargetYears}
+                    withdrawalRate={firePreferences.withdrawal_rate}
+                    onWithdrawalRateChange={() => {}}
+                    targetYears={firePreferences.target_years}
+                    onTargetYearsChange={() => {}}
                     fixedIncomeTotal={fixedIncomeTotal}
                     variableIncomeTotal={variableIncomeTotal}
                     equityTotal={equityTotal}
                     ifixTotal={ifixTotal}
                     monthlySavings={monthlySavings}
+                    simulatedExpenses={firePreferences.monthly_expenses_override}
+                    excludeIfixFromSim={firePreferences.exclude_ifix_from_sim}
+                    onProgressClick={openFireStrategy}
                     compact
                   />
                 ) : (
@@ -218,14 +223,17 @@ const Indicators = () => {
                     patrimonyTotal={(assetsIndicators?.total ?? 0) + bankAmount}
                     avgExpenses={expensesIndicators?.fire_avg ?? 0}
                     isLoading={isLoading || isExpensesIndicatorsLoading || isReportsLoading}
-                    withdrawalRate={fireWithdrawalRate}
-                    onWithdrawalRateChange={setFireWithdrawalRate}
-                    targetYears={targetYears}
-                    onTargetYearsChange={setTargetYears}
+                    withdrawalRate={firePreferences.withdrawal_rate}
+                    onWithdrawalRateChange={() => {}}
+                    targetYears={firePreferences.target_years}
+                    onTargetYearsChange={() => {}}
                     equityTotal={equityTotal}
                     ifixTotal={ifixTotal}
                     fixedIncomeTotal={fixedIncomeTotal + bankAmount}
                     monthlySavings={monthlySavings}
+                    simulatedExpenses={firePreferences.monthly_expenses_override}
+                    excludeIfixFromSim={firePreferences.exclude_ifix_from_sim}
+                    onProgressClick={openFireStrategy}
                     compact
                   />
                 )}

--- a/react/src/pages/private/Planning/PlanningHub.tsx
+++ b/react/src/pages/private/Planning/PlanningHub.tsx
@@ -28,7 +28,7 @@ import OneOverNIndicator from "../Home/OneOverNIndicator";
 import VPWIndicator from "../Home/VPWIndicator";
 import { usePlanningPreferences } from "./hooks";
 import { useSelectedMethod } from "./hooks";
-import type { ActiveMethodKey } from "./api";
+import { getFirePlanningPreferences, type ActiveMethodKey } from "./api";
 import { STRATEGY_CONTENT } from "./strategyContent";
 
 const STRATEGY_ORDER: ActiveMethodKey[] = [
@@ -41,6 +41,7 @@ const STRATEGY_ORDER: ActiveMethodKey[] = [
 const PlanningHub = () => {
   const { selectedMethod } = useSelectedMethod();
   const { data: planningData } = usePlanningPreferences();
+  const firePreferences = getFirePlanningPreferences(planningData?.preferences);
   const dateOfBirth = planningData?.dateOfBirth ?? null;
 
   const {
@@ -101,13 +102,15 @@ const PlanningHub = () => {
         patrimonyTotal={patrimonyTotal}
         avgExpenses={avgExpenses}
         isLoading={isDataLoading || isReportsLoading}
-        withdrawalRate={4}
+        withdrawalRate={firePreferences.withdrawal_rate}
         onWithdrawalRateChange={() => {}}
-        targetYears={30}
+        targetYears={firePreferences.target_years}
         onTargetYearsChange={() => {}}
         equityTotal={equityTotal}
         ifixTotal={ifixTotal}
         fixedIncomeTotal={fixedIncomeTotal + bankAmount}
+        simulatedExpenses={firePreferences.monthly_expenses_override}
+        excludeIfixFromSim={firePreferences.exclude_ifix_from_sim}
         compact
         hideLabel
       />

--- a/react/src/pages/private/Planning/StrategyDetailPage.tsx
+++ b/react/src/pages/private/Planning/StrategyDetailPage.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 import Button from "@mui/material/Button";
 import Chip from "@mui/material/Chip";
@@ -42,7 +42,11 @@ import {
   useSelectedMethod,
   useUpdatePlanningPreferences,
 } from "./hooks";
-import type { ActiveMethodKey } from "./api";
+import {
+  getFirePlanningPreferences,
+  type ActiveMethodKey,
+  type FirePlanningPreferences,
+} from "./api";
 import {
   STRATEGY_CONTENT,
   GALENO_RATIONALE,
@@ -98,14 +102,28 @@ const StrategyDetail = ({ method }: { method: ActiveMethodKey }) => {
   const [simulatedExpenses, setSimulatedExpenses] = useState<number | null>(
     null,
   );
+  const [excludeIfixFromSim, setExcludeIfixFromSim] = useState(false);
 
   // Data hooks
   const { selectedMethod } = useSelectedMethod();
   const { data: planningData } = usePlanningPreferences();
   const preferences = planningData?.preferences;
+  const firePreferences = getFirePlanningPreferences(preferences);
   const dateOfBirth = planningData?.dateOfBirth ?? null;
   const { mutate: updatePreferences, isPending: isUpdating } =
     useUpdatePlanningPreferences();
+
+  useEffect(() => {
+    setFireWithdrawalRate(firePreferences.withdrawal_rate);
+    setTargetYears(firePreferences.target_years);
+    setSimulatedExpenses(firePreferences.monthly_expenses_override);
+    setExcludeIfixFromSim(firePreferences.exclude_ifix_from_sim);
+  }, [
+    firePreferences.exclude_ifix_from_sim,
+    firePreferences.monthly_expenses_override,
+    firePreferences.target_years,
+    firePreferences.withdrawal_rate,
+  ]);
 
   const {
     data: assetsIndicators,
@@ -195,6 +213,30 @@ const StrategyDetail = ({ method }: { method: ActiveMethodKey }) => {
     }
   };
 
+  const updateFirePreferences = (fire: FirePlanningPreferences) => {
+    updatePreferences({ fire });
+  };
+
+  const handleFireWithdrawalRateChange = (value: number) => {
+    setFireWithdrawalRate(value);
+    updateFirePreferences({ withdrawal_rate: value });
+  };
+
+  const handleFireTargetYearsChange = (value: number) => {
+    setTargetYears(value);
+    updateFirePreferences({ target_years: value });
+  };
+
+  const handleFireSimulatedExpensesChange = (value: number | null) => {
+    setSimulatedExpenses(value);
+    updateFirePreferences({ monthly_expenses_override: value });
+  };
+
+  const handleFireExcludeIfixChange = (value: boolean) => {
+    setExcludeIfixFromSim(value);
+    updateFirePreferences({ exclude_ifix_from_sim: value });
+  };
+
   const content = STRATEGY_CONTENT[method];
   const displayTitle = showAgeInBonds
     ? (AGE_IN_BONDS_TITLES[method]?.title ?? content.title)
@@ -237,9 +279,9 @@ const StrategyDetail = ({ method }: { method: ActiveMethodKey }) => {
             isLoading={isDataLoading || isReportsLoading}
             dateOfBirth={dateOfBirth}
             withdrawalRate={fireWithdrawalRate}
-            onWithdrawalRateChange={setFireWithdrawalRate}
+            onWithdrawalRateChange={handleFireWithdrawalRateChange}
             targetYears={targetYears}
-            onTargetYearsChange={setTargetYears}
+            onTargetYearsChange={handleFireTargetYearsChange}
             fixedIncomeTotal={fixedIncomeTotal}
             variableIncomeTotal={variableIncomeTotal}
             equityTotal={equityTotal}
@@ -249,6 +291,10 @@ const StrategyDetail = ({ method }: { method: ActiveMethodKey }) => {
             onMonthlySavingsChange={setMonthlySavingsOverride}
             onMonthlySavingsReset={() => setMonthlySavingsOverride(null)}
             isMonthlySavingsOverridden={monthlySavingsOverride !== null}
+            simulatedExpenses={simulatedExpenses}
+            onSimulatedExpensesChange={handleFireSimulatedExpensesChange}
+            excludeIfixFromSim={excludeIfixFromSim}
+            onExcludeIfixFromSimChange={handleFireExcludeIfixChange}
           />
         ) : (
           <ConstantDollarIndicator
@@ -256,9 +302,9 @@ const StrategyDetail = ({ method }: { method: ActiveMethodKey }) => {
             avgExpenses={avgExpenses}
             isLoading={isDataLoading || isReportsLoading}
             withdrawalRate={fireWithdrawalRate}
-            onWithdrawalRateChange={setFireWithdrawalRate}
+            onWithdrawalRateChange={handleFireWithdrawalRateChange}
             targetYears={targetYears}
-            onTargetYearsChange={setTargetYears}
+            onTargetYearsChange={handleFireTargetYearsChange}
             equityTotal={equityTotal}
             ifixTotal={ifixTotal}
             fixedIncomeTotal={fixedIncomeTotal + bankAmount}
@@ -271,7 +317,9 @@ const StrategyDetail = ({ method }: { method: ActiveMethodKey }) => {
             simulatedPatrimony={simulatedPatrimony}
             onSimulatedPatrimonyChange={setSimulatedPatrimony}
             simulatedExpenses={simulatedExpenses}
-            onSimulatedExpensesChange={setSimulatedExpenses}
+            onSimulatedExpensesChange={handleFireSimulatedExpensesChange}
+            excludeIfixFromSim={excludeIfixFromSim}
+            onExcludeIfixFromSimChange={handleFireExcludeIfixChange}
           />
         );
       case "dividends_only":

--- a/react/src/pages/private/Planning/api.ts
+++ b/react/src/pages/private/Planning/api.ts
@@ -7,7 +7,29 @@ export type PlanningPreferences = {
   selected_method?: WithdrawalMethodKey;
   show_galeno?: boolean;
   show_age_in_bonds?: boolean;
+  fire?: FirePlanningPreferences;
 };
+
+export type FirePlanningPreferences = {
+  withdrawal_rate?: number;
+  target_years?: number;
+  monthly_expenses_override?: number | null;
+  exclude_ifix_from_sim?: boolean;
+};
+
+export const DEFAULT_FIRE_PREFERENCES = {
+  withdrawal_rate: 4,
+  target_years: 30,
+  monthly_expenses_override: null,
+  exclude_ifix_from_sim: false,
+} satisfies Required<FirePlanningPreferences>;
+
+export const getFirePlanningPreferences = (
+  preferences?: PlanningPreferences,
+): Required<FirePlanningPreferences> => ({
+  ...DEFAULT_FIRE_PREFERENCES,
+  ...(preferences?.fire ?? {}),
+});
 
 export type PlanningData = {
   preferences: PlanningPreferences;


### PR DESCRIPTION
Persists FIRE inputs that affect the target/progress calculation in planning preferences, wires Home and Planning to use those saved values, makes the Home FIRE progress bar link to the FIRE strategy page, and includes the current IRPF report updates in the branch.\n\nValidation run before commit:\n- ruff on changed Django files\n- pytest authentication/tests/test__user__views.py variable_income_assets/tests/test_queries.py -q\n- React build\n- git diff --check