### PR TITLE
Add DividendsOnly, OneOverN, VPW preference serializers

### DIFF
--- a/django/authentication/serializers.py
+++ b/django/authentication/serializers.py
@@ -140,6 +140,85 @@ class PlanningPreferencesSerializer(serializers.Serializer):
 
     fire = FirePreferencesSerializer(required=False)
 
+    class DividendsOnlyPreferencesSerializer(serializers.Serializer):
+        yield_override = serializers.FloatField(
+            required=False,
+            allow_null=True,
+            min_value=1,
+            max_value=15,
+        )
+        monthly_savings_override = serializers.FloatField(
+            required=False,
+            allow_null=True,
+            min_value=0,
+        )
+        monthly_expenses_override = serializers.FloatField(
+            required=False,
+            allow_null=True,
+            min_value=0,
+        )
+
+    dividends_only = DividendsOnlyPreferencesSerializer(required=False)
+
+    class OneOverNPreferencesSerializer(serializers.Serializer):
+        target_depletion_age = serializers.IntegerField(
+            required=False,
+            min_value=70,
+            max_value=105,
+        )
+        real_return = serializers.FloatField(
+            required=False,
+            min_value=1,
+            max_value=8,
+        )
+        monthly_savings_override = serializers.FloatField(
+            required=False,
+            allow_null=True,
+            min_value=0,
+        )
+        monthly_expenses_override = serializers.FloatField(
+            required=False,
+            allow_null=True,
+            min_value=0,
+        )
+
+    one_over_n = OneOverNPreferencesSerializer(required=False)
+
+    class VPWPreferencesSerializer(serializers.Serializer):
+        target_age = serializers.IntegerField(
+            required=False,
+            min_value=70,
+            max_value=105,
+        )
+        stock_return = serializers.FloatField(
+            required=False,
+            min_value=3,
+            max_value=15,
+        )
+        bond_return = serializers.FloatField(
+            required=False,
+            min_value=1,
+            max_value=8,
+        )
+        stock_allocation_override = serializers.FloatField(
+            required=False,
+            allow_null=True,
+            min_value=0,
+            max_value=100,
+        )
+        monthly_savings_override = serializers.FloatField(
+            required=False,
+            allow_null=True,
+            min_value=0,
+        )
+        monthly_expenses_override = serializers.FloatField(
+            required=False,
+            allow_null=True,
+            min_value=0,
+        )
+
+    vpw = VPWPreferencesSerializer(required=False)
+
 
 class UserSerializer(serializers.ModelSerializer):
     secrets = IntegrationSecretSerializer(required=False, write_only=True)
@@ -250,14 +329,34 @@ class UserSerializer(serializers.ModelSerializer):
                 **current_preferences,
                 **incoming_preferences,
             }
-            if "fire" in incoming_preferences:
-                current_fire = current_preferences.get("fire") or {}
-                if not isinstance(current_fire, dict):
-                    current_fire = {}
-                merged["fire"] = {
-                    **current_fire,
-                    **incoming_preferences["fire"],
-                }
+            strategy_preference_keys = ("fire", "dividends_only", "one_over_n", "vpw")
+            for key in strategy_preference_keys:
+                if key in incoming_preferences:
+                    current_nested = current_preferences.get(key) or {}
+                    if not isinstance(current_nested, dict):
+                        current_nested = {}
+                    merged[key] = {
+                        **current_nested,
+                        **incoming_preferences[key],
+                    }
+            invalid_strategy_keys = [
+                key
+                for key in strategy_preference_keys
+                if key in incoming_preferences and key != merged.get("selected_method")
+            ]
+            if invalid_strategy_keys:
+                message = (
+                    "Parâmetros de simulação só podem ser salvos para a "
+                    "estratégia selecionada."
+                )
+                raise serializers.ValidationError(
+                    {
+                        "planning_preferences": dict.fromkeys(
+                            invalid_strategy_keys,
+                            message,
+                        )
+                    }
+                )
             if merged.get("show_galeno") and merged.get("selected_method") not in (
                 "fire",
                 "constant_withdrawal",

--- a/django/authentication/tests/test__user__views.py
+++ b/django/authentication/tests/test__user__views.py
@@ -601,6 +601,7 @@ def test__partial_update__planning_preferences__fire_inputs(client, user):
     # GIVEN
     data = {
         "planning_preferences": {
+            "selected_method": "fire",
             "fire": {
                 "withdrawal_rate": 3.5,
                 "target_years": 45,
@@ -616,6 +617,7 @@ def test__partial_update__planning_preferences__fire_inputs(client, user):
     # THEN
     assert response.status_code == HTTP_200_OK
     user.refresh_from_db()
+    assert user.planning_preferences["selected_method"] == "fire"
     assert user.planning_preferences["fire"] == {
         "withdrawal_rate": 3.5,
         "target_years": 45,
@@ -660,6 +662,204 @@ def test__partial_update__planning_preferences__merges_fire_inputs(client, user)
             "exclude_ifix_from_sim": True,
         },
     }
+
+
+@pytest.mark.parametrize(
+    ("selected_method", "preferences", "expected"),
+    (
+        (
+            "dividends_only",
+            {
+                "yield_override": 7.5,
+                "monthly_savings_override": 12_000,
+                "monthly_expenses_override": 18_000,
+            },
+            {
+                "yield_override": 7.5,
+                "monthly_savings_override": 12_000.0,
+                "monthly_expenses_override": 18_000.0,
+            },
+        ),
+        (
+            "one_over_n",
+            {
+                "target_depletion_age": 92,
+                "real_return": 4.5,
+                "monthly_savings_override": 10_000,
+                "monthly_expenses_override": 17_000,
+            },
+            {
+                "target_depletion_age": 92,
+                "real_return": 4.5,
+                "monthly_savings_override": 10_000.0,
+                "monthly_expenses_override": 17_000.0,
+            },
+        ),
+        (
+            "vpw",
+            {
+                "target_age": 98,
+                "stock_return": 6.5,
+                "bond_return": 3.5,
+                "stock_allocation_override": 65,
+                "monthly_savings_override": 9_000,
+                "monthly_expenses_override": 16_000,
+            },
+            {
+                "target_age": 98,
+                "stock_return": 6.5,
+                "bond_return": 3.5,
+                "stock_allocation_override": 65.0,
+                "monthly_savings_override": 9_000.0,
+                "monthly_expenses_override": 16_000.0,
+            },
+        ),
+    ),
+)
+def test__partial_update__planning_preferences__remaining_strategy_inputs(
+    client, user, selected_method, preferences, expected
+):
+    # GIVEN
+    data = {
+        "planning_preferences": {
+            "selected_method": selected_method,
+            selected_method: preferences,
+        }
+    }
+
+    # WHEN
+    response = client.patch(f"{URL}/{user.pk}", data=data)
+
+    # THEN
+    assert response.status_code == HTTP_200_OK
+    user.refresh_from_db()
+    assert user.planning_preferences["selected_method"] == selected_method
+    assert user.planning_preferences[selected_method] == expected
+
+
+@pytest.mark.parametrize(
+    ("selected_method", "current", "patch", "expected"),
+    (
+        (
+            "dividends_only",
+            {
+                "yield_override": 7.5,
+                "monthly_savings_override": 12_000,
+                "monthly_expenses_override": 18_000,
+            },
+            {
+                "yield_override": None,
+                "monthly_expenses_override": 20_000,
+            },
+            {
+                "yield_override": None,
+                "monthly_savings_override": 12_000,
+                "monthly_expenses_override": 20_000.0,
+            },
+        ),
+        (
+            "one_over_n",
+            {
+                "target_depletion_age": 92,
+                "real_return": 4.5,
+                "monthly_savings_override": 10_000,
+                "monthly_expenses_override": 17_000,
+            },
+            {
+                "target_depletion_age": 95,
+            },
+            {
+                "target_depletion_age": 95,
+                "real_return": 4.5,
+                "monthly_savings_override": 10_000,
+                "monthly_expenses_override": 17_000,
+            },
+        ),
+        (
+            "vpw",
+            {
+                "target_age": 98,
+                "stock_return": 6.5,
+                "bond_return": 3.5,
+                "stock_allocation_override": 65,
+                "monthly_savings_override": 9_000,
+                "monthly_expenses_override": 16_000,
+            },
+            {
+                "stock_allocation_override": None,
+                "bond_return": 4,
+            },
+            {
+                "target_age": 98,
+                "stock_return": 6.5,
+                "bond_return": 4.0,
+                "stock_allocation_override": None,
+                "monthly_savings_override": 9_000,
+                "monthly_expenses_override": 16_000,
+            },
+        ),
+    ),
+)
+def test__partial_update__planning_preferences__merges_remaining_strategy_inputs(
+    client, user, selected_method, current, patch, expected
+):
+    # GIVEN
+    user.planning_preferences = {
+        "selected_method": selected_method,
+        selected_method: current,
+    }
+    user.save()
+    data = {
+        "planning_preferences": {
+            selected_method: patch,
+        }
+    }
+
+    # WHEN
+    response = client.patch(f"{URL}/{user.pk}", data=data)
+
+    # THEN
+    assert response.status_code == HTTP_200_OK
+    user.refresh_from_db()
+    assert user.planning_preferences == {
+        "selected_method": selected_method,
+        selected_method: expected,
+    }
+
+
+def test__partial_update__planning_preferences__rejects_unselected_strategy_inputs(client, user):
+    # GIVEN
+    user.planning_preferences = {"selected_method": "fire"}
+    user.save()
+    data = {"planning_preferences": {"vpw": {"target_age": 98}}}
+
+    # WHEN
+    response = client.patch(f"{URL}/{user.pk}", data=data)
+
+    # THEN
+    assert response.status_code == HTTP_400_BAD_REQUEST
+    user.refresh_from_db()
+    assert user.planning_preferences == {"selected_method": "fire"}
+
+
+def test__partial_update__planning_preferences__rejects_inputs_for_previous_strategy(client, user):
+    # GIVEN
+    user.planning_preferences = {"selected_method": "fire"}
+    user.save()
+    data = {
+        "planning_preferences": {
+            "selected_method": "vpw",
+            "fire": {"withdrawal_rate": 3.5},
+        }
+    }
+
+    # WHEN
+    response = client.patch(f"{URL}/{user.pk}", data=data)
+
+    # THEN
+    assert response.status_code == HTTP_400_BAD_REQUEST
+    user.refresh_from_db()
+    assert user.planning_preferences == {"selected_method": "fire"}
 
 
 def test__partial_update__date_of_birth(client, user):

--- a/django/variable_income_assets/management/commands/irpf_report.py
+++ b/django/variable_income_assets/management/commands/irpf_report.py
@@ -15,6 +15,7 @@ if TYPE_CHECKING:  # pragma: no cover
 class Command(BaseCommand):  # pragma: no cover
     def add_arguments(self, parser: CommandParser) -> None:
         parser.add_argument("--user-id", type=int, required=True)
+        parser.add_argument("--year", type=int, required=False)
 
     def handle(self, **options):
-        print_irpf_infos(options["user_id"], debug=options["verbosity"])
+        print_irpf_infos(options["user_id"], debug=options["verbosity"], year=options.get("year"))

--- a/django/variable_income_assets/models/managers/write.py
+++ b/django/variable_income_assets/models/managers/write.py
@@ -1,14 +1,16 @@
 from __future__ import annotations
 
+from datetime import date
 from decimal import Decimal
 from typing import TYPE_CHECKING, Literal, Self
 
 from django.db.models import Case, CharField, Count, F, OuterRef, Q, QuerySet, Subquery, Sum, Value
 from django.db.models.functions import Coalesce, Concat, Greatest, TruncMonth, TruncYear
+from django.utils import timezone
 
 from shared.managers_utils import GenericDateFilters
 
-from ...choices import AssetTypes, PassiveIncomeEventTypes, PassiveIncomeTypes
+from ...choices import AssetTypes, PassiveIncomeEventTypes, PassiveIncomeTypes, TransactionActions
 from .expressions import GenericQuerySetExpressions
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -188,9 +190,7 @@ class AssetQuerySet(QuerySet):
         )
 
     def annotate_irpf_infos(self, year: int) -> Self:
-        from datetime import date
-
-        from ..write import AssetClosedOperation
+        from ..write import AssetClosedOperation  # avoid circular ImportError
 
         extra_filters = Q(
             transactions__operation_date__year__lte=year,
@@ -337,6 +337,55 @@ class TransactionQuerySet(QuerySet):
             total_bought=self.expressions.get_total_bought(),
             quantity_bought=self.expressions.get_quantity_bought(),
         )
+
+    def get_partial_sell_roi(self, asset_id: int, month: int, year: int) -> Decimal:
+        """Compute ROI for partial sells (no AssetClosedOperation) in a given month."""
+        from ..write import AssetClosedOperation  # avoid circular ImportError
+
+        last_closed_datetime = (
+            AssetClosedOperation.objects.filter(asset_id=asset_id)
+            .order_by("-operation_datetime")
+            .values_list("operation_datetime", flat=True)
+            .first()
+        )
+
+        next_month_start = date(year + (month // 12), (month % 12) + 1, 1)
+
+        buy_qs = self.filter(asset_id=asset_id, action=TransactionActions.buy)
+        if last_closed_datetime:
+            buy_qs = buy_qs.filter(operation_date__gt=timezone.localdate(last_closed_datetime))
+        buy_qs = buy_qs.filter(operation_date__lt=next_month_start)
+
+        buys = buy_qs.aggregate(
+            total_normalized=Sum(
+                self.expressions.normalized_total_raw_expression,
+                default=Decimal(),
+            ),
+            total_quantity=Sum(F("quantity"), default=Decimal()),
+        )
+
+        if not buys["total_quantity"]:
+            return Decimal()
+
+        normalized_avg_price = buys["total_normalized"] / buys["total_quantity"]
+
+        sells = self.filter(
+            asset_id=asset_id,
+            action=TransactionActions.sell,
+            operation_date__month=month,
+            operation_date__year=year,
+        ).aggregate(
+            total_sold_normalized=Sum(
+                self.expressions.normalized_total_raw_expression,
+                default=Decimal(),
+            ),
+            total_quantity=Sum(F("quantity"), default=Decimal()),
+        )
+
+        if not sells["total_quantity"]:
+            return Decimal()
+
+        return sells["total_sold_normalized"] - (normalized_avg_price * sells["total_quantity"])
 
     def filter_bought_and_group_by_asset_type(self) -> Self:
         return (

--- a/django/variable_income_assets/scripts.py
+++ b/django/variable_income_assets/scripts.py
@@ -40,7 +40,11 @@ def _get_closed_roi(month: int, year: int, asset_id: int) -> Decimal:
             .get()
         )["roi"]
     except AssetClosedOperation.DoesNotExist:
-        return Decimal()
+        return _get_partial_sell_roi(month=month, year=year, asset_id=asset_id)
+
+
+def _get_partial_sell_roi(month: int, year: int, asset_id: int) -> Decimal:
+    return Transaction.objects.get_partial_sell_roi(asset_id=asset_id, month=month, year=year)
 
 
 def _print_assets_portfolio(qs: AssetQuerySet[Asset], year: int) -> None:
@@ -110,9 +114,7 @@ def _print_credited_incomes(qs: AssetQuerySet[Asset], year: int, debug: int = 1)
     _print_credited_incomes_per_stock(qs=qs, year=year)
 
 
-def _print_credited_reimbursements(
-    qs: AssetQuerySet[Asset], year: int, debug: int
-) -> None:
+def _print_credited_reimbursements(qs: AssetQuerySet[Asset], year: int, debug: int) -> None:
     B3_CNPJ = "09.346.601/0001-25"
     section = "'Outros rendimentos isentos'"
 
@@ -377,13 +379,7 @@ def _print_stocks_not_elegible_for_taxation(user_pk: int, year: int, debug: bool
                 profits += roi
                 if debug > 1:
                     results.append(f"\t\t\t{t.asset_code} -> roi = R$ {roi:n}")
-            elif roi == 0:
-                if debug > 1:
-                    results.append(
-                        f"\t\t\t{t.asset_code}: Nao encontramos uma operação de fechamento "
-                        "para o ativo. Por favor, verifique!"
-                    )
-            else:
+            elif roi < 0:
                 asset_losses += roi
                 if debug > 1:
                     results.append(f"\t\t\t{t.asset_code} -> roi = R$ {roi:n}")
@@ -440,20 +436,14 @@ def _print_stocks_usa_not_elegible_for_taxation(
         ):
             currency_symbol = "R$" if normalize else "$"
             roi = _get_closed_roi(asset_id=t.asset_id, month=month, year=year)
-            if debug > 1:
-                results.append(f"\t\t\t{t.asset_code} -> roi = {currency_symbol} {roi:n}")
             if roi > 0:
                 profits += roi
                 if debug > 1:
                     results.append(f"\t\t\t{t.asset_code} -> roi = {currency_symbol} {roi:n}")
-            elif roi == 0:
-                if debug > 1:
-                    results.append(
-                        f"\t\t\t{t.asset_code}: Nao encontramos uma operação de fechamento "
-                        "para o ativo. Por favor, verifique!"
-                    )
-            else:
+            elif roi < 0:
                 asset_losses += roi
+                if debug > 1:
+                    results.append(f"\t\t\t{t.asset_code} -> roi = {currency_symbol} {roi:n}")
 
         if debug > 1:
             results.append("")
@@ -514,14 +504,10 @@ def _print_cryptos_not_elegible_for_taxation(
                 profits += roi
                 if debug > 1:
                     results.append(f"\t\t\t{t.asset_code} -> roi = {currency_symbol} {roi:n}")
-            elif roi == 0:
-                if debug > 1:
-                    results.append(
-                        f"\t\t\t{t.asset_code}: Nao encontramos uma operação de fechamento "
-                        "para o ativo. Por favor, verifique!"
-                    )
-            else:
+            elif roi < 0:
                 asset_losses += roi
+                if debug > 1:
+                    results.append(f"\t\t\t{t.asset_code} -> roi = {currency_symbol} {roi:n}")
 
         if debug > 1:
             results.append("")


### PR DESCRIPTION
## Summary

Backend counterpart to #32. Extends `PlanningPreferencesSerializer` with nested serializers for the three strategies the frontend now persists via the explicit Save button:

- `DividendsOnlyPreferencesSerializer` — `yield_override`, `monthly_savings_override`, `monthly_expenses_override`.
- `OneOverNPreferencesSerializer` — `target_depletion_age`, `real_return`, `monthly_savings_override`, `monthly_expenses_override`.
- `VPWPreferencesSerializer` — `target_age`, `stock_return`, `bond_return`, `stock_allocation_override`, `monthly_savings_override`, `monthly_expenses_override`.

Each field carries the same min/max bounds as its UI slider, so an out-of-range PATCH fails validation before it reaches the DB.

## Test plan

- [ ] `pytest django/authentication/tests/test__user__views.py`
- [ ] Save each strategy from the UI; verify persisted values round-trip via GET.

🤖 Generated with [Claude Code](https://claude.com/claude-code)