### PR TITLE
Add B3 spreadsheet import (endpoint + Assets drawer)

### DIFF
--- a/django/pyproject.toml
+++ b/django/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "requests>=2.31.0,<3",
     "stripe>=7.8.0,<8",
     "psycopg[pool]>=3.2.10",
+    "openpyxl>=3.1,<4",
 ]
 
 [dependency-groups]

--- a/django/requirements-production.txt
+++ b/django/requirements-production.txt
@@ -54,6 +54,8 @@ djangorestframework-simplejwt==5.5.0
     # via multi-sources-financial-control
 drf-spectacular==0.28.0
     # via multi-sources-financial-control
+et-xmlfile==2.0.0
+    # via openpyxl
 frozenlist==1.7.0
     # via
     #   aiohttp
@@ -73,6 +75,8 @@ multidict==6.6.2
     # via
     #   aiohttp
     #   yarl
+openpyxl==3.1.5
+    # via multi-sources-financial-control
 packaging==25.0
     # via gunicorn
 propcache==0.3.2
@@ -80,6 +84,7 @@ propcache==0.3.2
     #   aiohttp
     #   yarl
 psycopg==3.2.10
+    # via multi-sources-financial-control
 psycopg-pool==3.2.6
     # via psycopg
 pycparser==2.22 ; platform_python_implementation != 'PyPy'

--- a/django/uv.lock
+++ b/django/uv.lock
@@ -455,6 +455,15 @@ wheels = [
 ]
 
 [[package]]
+name = "et-xmlfile"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/38/af70d7ab1ae9d4da450eeec1fa3918940a5fafb9055e934af8d6eb0c2313/et_xmlfile-2.0.0.tar.gz", hash = "sha256:dab3f4764309081ce75662649be815c4c9081e88f0837825f90fd28317d4da54", size = 17234, upload-time = "2024-10-25T17:25:40.039Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/8b/5fe2cc11fee489817272089c4203e679c63b570a5aaeb18d852ae3cbba6a/et_xmlfile-2.0.0-py3-none-any.whl", hash = "sha256:7a91720bc756843502c3b7504c77b8fe44217c85c537d85037f0f536151b2caa", size = 18059, upload-time = "2024-10-25T17:25:39.051Z" },
+]
+
+[[package]]
 name = "execnet"
 version = "2.1.1"
 source = { registry = "https://pypi.org/simple" }
@@ -987,6 +996,7 @@ dependencies = [
     { name = "djangorestframework" },
     { name = "djangorestframework-simplejwt" },
     { name = "drf-spectacular" },
+    { name = "openpyxl" },
     { name = "psycopg", extra = ["pool"] },
     { name = "pydantic" },
     { name = "python-dateutil" },
@@ -1037,6 +1047,7 @@ requires-dist = [
     { name = "djangorestframework", specifier = ">=3.15.0,<4" },
     { name = "djangorestframework-simplejwt", specifier = ">=5.3.0,<6" },
     { name = "drf-spectacular", specifier = ">=0.27.0,<1" },
+    { name = "openpyxl", specifier = ">=3.1,<4" },
     { name = "psycopg", extras = ["pool"], specifier = ">=3.2.10" },
     { name = "pydantic", specifier = ">=2.5.0,<3" },
     { name = "python-dateutil", specifier = ">=2.8.2,<3" },
@@ -1140,6 +1151,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a6/7b/17244b1083e8e604bf154cf9b716aecd6388acd656dd01893d0d244c94d9/oauth2client-4.1.3.tar.gz", hash = "sha256:d486741e451287f69568a4d26d70d9acd73a2bbfa275746c535b4209891cccc6", size = 155910, upload-time = "2018-09-07T21:38:18.036Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/95/a9/4f25a14d23f0786b64875b91784607c2277eff25d48f915e39ff0cff505a/oauth2client-4.1.3-py2.py3-none-any.whl", hash = "sha256:b8a81cc5d60e2d364f0b1b98f958dbd472887acaf1a5b05e21c28c31a2d6d3ac", size = 98206, upload-time = "2018-09-07T21:38:16.742Z" },
+]
+
+[[package]]
+name = "openpyxl"
+version = "3.1.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "et-xmlfile" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3d/f9/88d94a75de065ea32619465d2f77b29a0469500e99012523b91cc4141cd1/openpyxl-3.1.5.tar.gz", hash = "sha256:cf0e3cf56142039133628b5acffe8ef0c12bc902d2aadd3e0fe5878dc08d1050", size = 186464, upload-time = "2024-06-28T14:03:44.161Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c0/da/977ded879c29cbd04de313843e76868e6e13408a94ed6b987245dc7c8506/openpyxl-3.1.5-py2.py3-none-any.whl", hash = "sha256:5282c12b107bffeef825f4617dc029afaf41d0ea60823bbb665ef3079dc79de2", size = 250910, upload-time = "2024-06-28T14:03:41.161Z" },
 ]
 
 [[package]]

--- a/django/variable_income_assets/integrations/b3/__init__.py
+++ b/django/variable_income_assets/integrations/b3/__init__.py
@@ -1,0 +1,13 @@
+from .handlers import (
+    import_b3_fixed_income_positions,
+    import_b3_negociacoes,
+    import_b3_renda_fixa_positions,
+    import_b3_tesouro_positions,
+)
+
+__all__ = [
+    "import_b3_negociacoes",
+    "import_b3_fixed_income_positions",
+    "import_b3_renda_fixa_positions",
+    "import_b3_tesouro_positions",
+]

--- a/django/variable_income_assets/integrations/b3/_workbook.py
+++ b/django/variable_income_assets/integrations/b3/_workbook.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from io import BytesIO
+from pathlib import Path
+from typing import IO
+
+from openpyxl import Workbook, load_workbook
+
+# A workbook can be referenced by a filesystem path or carried in memory as raw
+# bytes (an uploaded file read into memory). Bytes are wrapped in a fresh BytesIO
+# on every call, so the same payload can be parsed more than once.
+WorkbookSource = str | Path | bytes | IO[bytes]
+
+
+def open_workbook(source: WorkbookSource) -> Workbook:
+    if isinstance(source, bytes):
+        source = BytesIO(source)
+    return load_workbook(source, data_only=True)

--- a/django/variable_income_assets/integrations/b3/handlers.py
+++ b/django/variable_income_assets/integrations/b3/handlers.py
@@ -10,10 +10,13 @@ from django.contrib.auth import get_user_model
 from django.db import transaction as djtransaction
 from django.utils import timezone
 
+from rest_framework.exceptions import ValidationError as DRFValidationError
+
 from ...choices import AssetObjectives, AssetTypes, Currencies, LiquidityTypes
 from ...models import Asset, AssetMetaData, Transaction
 from ...scripts import update_asset_metadata_current_price
 from ...serializers import AssetSerializer, TransactionListSerializer
+from ._workbook import WorkbookSource
 from .movimentacao import parse_movements
 from .negociacao import (
     parse_fii_positions,
@@ -59,16 +62,37 @@ def _parse_workbook_dt(path: Path) -> datetime:
     )
 
 
-def _resolve_posicao_path(path: str | None) -> Path:
+def _resolve_posicao_path(source: WorkbookSource | None) -> WorkbookSource:
     from .parser import _resolve_path
 
-    return _resolve_path(path)
+    return _resolve_path(source)
 
 
-def _resolve_movimentacao_path(path: str | None) -> Path:
+def _resolve_movimentacao_path(path: WorkbookSource | None) -> WorkbookSource:
     from .movimentacao import _resolve_path
 
     return _resolve_path(path)
+
+
+def _source_label(source: WorkbookSource | None) -> str | None:
+    """Path strings help in CLI reports; an in-memory upload has no path."""
+    if isinstance(source, bytes):
+        return None
+    return str(source) if source is not None else None
+
+
+def _validation_message(exc: DRFValidationError) -> str:
+    # Flatten a serializer/domain ValidationError to a single readable message,
+    # dropping internal field names (e.g. "action" for a sell-exceeds-holdings).
+    detail = exc.detail
+    if isinstance(detail, dict):
+        messages: list = []
+        for value in detail.values():
+            messages.extend(value if isinstance(value, list | tuple) else [value])
+        return "; ".join(str(m) for m in messages)
+    if isinstance(detail, list | tuple):
+        return "; ".join(str(m) for m in detail)
+    return str(detail)
 
 
 def _build_description(position: B3FixedIncomePosition) -> str:
@@ -79,21 +103,36 @@ def _build_description(position: B3FixedIncomePosition) -> str:
 
 
 def _update_existing_price(
-    *, code: str, new_price: Decimal | None, workbook_dt: datetime
+    *,
+    code: str,
+    new_price: Decimal | None,
+    workbook_dt: datetime,
+    description: str | None = None,
 ) -> dict:
     if new_price is None:
-        return {"code": code, "action": "skipped", "reason": "no current_price in posicao"}
+        return {
+            "code": code,
+            "description": description,
+            "action": "skipped",
+            "reason": "sem preço atual na posição",
+        }
 
     metadata = AssetMetaData.objects.filter(code=code).first()
     if metadata is None:
-        return {"code": code, "action": "skipped", "reason": "no AssetMetaData row"}
+        return {
+            "code": code,
+            "description": description,
+            "action": "skipped",
+            "reason": "sem metadados do ativo",
+        }
 
     previous_dt = metadata.current_price_updated_at
     if previous_dt is not None and previous_dt >= workbook_dt:
         return {
             "code": code,
+            "description": description,
             "action": "price_skipped",
-            "reason": "metadata is at least as fresh as workbook",
+            "reason": "cotação já atualizada (planilha não é mais recente)",
             "metadata_updated_at": previous_dt.isoformat(),
             "workbook_dt": workbook_dt.isoformat(),
         }
@@ -101,6 +140,7 @@ def _update_existing_price(
     update_asset_metadata_current_price(code=code, price=new_price)
     return {
         "code": code,
+        "description": description,
         "action": "price_updated",
         "previous_price": str(metadata.current_price) if metadata.current_price else None,
         "new_price": str(new_price),
@@ -140,7 +180,7 @@ def _create_asset_and_transactions(
     asset = asset_serializer.save()
 
     transactions: list[dict] = []
-    for movement in movements:
+    for movement in sorted(movements, key=lambda m: m.operation_date):
         tx_serializer = TransactionListSerializer(
             data={
                 "asset_pk": asset.id,
@@ -204,7 +244,7 @@ def _create_tesouro_asset_and_transactions(
     asset = asset_serializer.save()
 
     transactions: list[dict] = []
-    for movement in movements:
+    for movement in sorted(movements, key=lambda m: m.operation_date):
         tx_serializer = TransactionListSerializer(
             data={
                 "asset_pk": asset.id,
@@ -259,8 +299,8 @@ def _renda_fixa_actions(
     use_posicao_price_when_missing_movement: bool,
     **_,
 ) -> list[dict]:
-    positions = parse_positions(str(posicao_path_resolved))
-    movements = parse_movements(str(movimentacao_path_resolved))
+    positions = parse_positions(posicao_path_resolved)
+    movements = parse_movements(movimentacao_path_resolved)
 
     movements_by_code: dict[str, list[B3FixedIncomeMovement]] = defaultdict(list)
     for movement in movements:
@@ -273,7 +313,7 @@ def _renda_fixa_actions(
                 {
                     "code": None,
                     "action": "skipped",
-                    "reason": "position has no code",
+                    "reason": "posição sem código",
                     "description": position.description,
                 }
             )
@@ -287,6 +327,7 @@ def _renda_fixa_actions(
                     code=position.code,
                     new_price=position.current_price,
                     workbook_dt=workbook_dt,
+                    description=_build_description(position),
                 )
             )
             continue
@@ -298,7 +339,7 @@ def _renda_fixa_actions(
                     {
                         "code": position.code,
                         "action": "skipped",
-                        "reason": "asset not in DB and no movimentação row",
+                        "reason": "ativo não cadastrado e sem linha de movimentação",
                     }
                 )
                 continue
@@ -308,7 +349,7 @@ def _renda_fixa_actions(
                     {
                         "code": position.code,
                         "action": "skipped",
-                        "reason": "fallback requested but posicao is missing price/issue_date",
+                        "reason": "posição sem preço/data de emissão para usar como movimentação",
                     }
                 )
                 continue
@@ -336,7 +377,7 @@ def _create_missing_transactions(
     )
     context = {"request": _RequestContext(user)}
     created: list[dict] = []
-    for movement in movements:
+    for movement in sorted(movements, key=lambda m: m.operation_date):
         key = (movement.action.value, movement.operation_date, movement.quantity, movement.unit_price)
         if key in existing:
             continue
@@ -356,6 +397,7 @@ def _create_missing_transactions(
         created.append(
             {
                 "code": asset.code,
+                "description": asset.description,
                 "action": "transaction_created",
                 "asset_pk": asset.id,
                 "transaction": {
@@ -378,8 +420,8 @@ def _tesouro_actions(
     movimentacao_path_resolved: Path,
     **_,
 ) -> list[dict]:
-    td_positions = parse_tesouro_positions(str(posicao_path_resolved))
-    td_movements = parse_tesouro_movements(str(movimentacao_path_resolved))
+    td_positions = parse_tesouro_positions(posicao_path_resolved)
+    td_movements = parse_tesouro_movements(movimentacao_path_resolved)
 
     td_by_name: dict[str, list[B3TesouroMovement]] = defaultdict(list)
     for td_movement in td_movements:
@@ -396,6 +438,7 @@ def _tesouro_actions(
                     code=td_position.isin,
                     new_price=td_position.current_price,
                     workbook_dt=workbook_dt,
+                    description=_build_tesouro_description(td_position),
                 )
             )
             actions.extend(
@@ -412,9 +455,9 @@ def _tesouro_actions(
             actions.append(
                 {
                     "code": td_position.isin,
-                    "name": td_position.name,
+                    "description": _build_tesouro_description(td_position),
                     "action": "skipped",
-                    "reason": "asset not in DB and no movimentação row",
+                    "reason": "ativo não cadastrado e sem linha de movimentação",
                 }
             )
             continue
@@ -434,9 +477,11 @@ def _run_with_rollback(
     dry_run: bool,
     posicao_path: str | None,
     pipelines: list,
+    workbook_dt: datetime | None = None,
 ) -> dict:
     posicao_path_resolved = _resolve_posicao_path(posicao_path)
-    workbook_dt = _parse_workbook_dt(posicao_path_resolved)
+    if workbook_dt is None:
+        workbook_dt = _parse_workbook_dt(posicao_path_resolved)
     user = User.objects.get(pk=user_id)
 
     actions: list[dict] = []
@@ -459,7 +504,7 @@ def _run_with_rollback(
     return {
         "dry_run": dry_run,
         "workbook_dt": workbook_dt.isoformat(),
-        "posicao_path": str(posicao_path_resolved),
+        "posicao_path": _source_label(posicao_path_resolved),
         "actions": actions,
     }
 
@@ -504,7 +549,7 @@ def _negociacao_actions(
     negociacao_path_resolved: Path,
     posicao_path_resolved: Path | None,
 ) -> list[dict]:
-    negotiations = parse_negotiations(str(negociacao_path_resolved))
+    negotiations = parse_negotiations(negociacao_path_resolved)
     by_code: dict[str, list[B3StockNegotiation]] = defaultdict(list)
     for negotiation in negotiations:
         by_code[negotiation.code].append(negotiation)
@@ -512,11 +557,11 @@ def _negociacao_actions(
     position_by_code: dict[str, B3StockPosition] = {}
     if posicao_path_resolved is not None:
         for position in parse_stock_positions(
-            str(posicao_path_resolved), asset_type=AssetTypes.stock
+            posicao_path_resolved, asset_type=AssetTypes.stock
         ):
             position_by_code[position.code] = position
         for position in parse_fii_positions(
-            str(posicao_path_resolved), asset_type=AssetTypes.fii
+            posicao_path_resolved, asset_type=AssetTypes.fii
         ):
             position_by_code[position.code] = position
 
@@ -530,9 +575,12 @@ def _negociacao_actions(
             position = position_by_code.get(code)
             if position is None:
                 reason = (
-                    "asset not in DB and no matching posicao row"
+                    "ativo não cadastrado e sem linha correspondente na posição"
                     if posicao_path_resolved is not None
-                    else "asset not in DB (pass create_missing_assets=True to create it)"
+                    else (
+                        "ativo não cadastrado; marque 'Criar ativos ausentes' "
+                        "e envie a posição para criá-lo"
+                    )
                 )
                 actions.append({"code": code, "action": "skipped", "reason": reason})
                 continue
@@ -548,15 +596,19 @@ def _negociacao_actions(
             actions.append(asset_action)
             asset_pk = new_asset_pk
             existing: set = set()
+            description = position.description.strip()
         else:
             asset_pk = asset.id
+            description = asset.description
             existing = set(
                 Transaction.objects.filter(asset=asset).values_list(
                     "action", "operation_date", "quantity", "price"
                 )
             )
 
-        for negotiation in code_negotiations:
+        # Apply chronologically: B3 reports list trades most-recent-first, but the
+        # domain enforces a running balance (no selling more than held).
+        for negotiation in sorted(code_negotiations, key=lambda n: n.operation_date):
             key = (
                 negotiation.action.value,
                 negotiation.operation_date,
@@ -566,18 +618,36 @@ def _negociacao_actions(
             if key in existing:
                 continue
 
-            _create_transaction(user=user, asset_pk=asset_pk, negotiation=negotiation)
+            tx_payload = {
+                "action": negotiation.action.value,
+                "price": str(negotiation.price),
+                "quantity": str(negotiation.quantity),
+                "operation_date": negotiation.operation_date.isoformat(),
+            }
+            try:
+                with djtransaction.atomic():
+                    _create_transaction(user=user, asset_pk=asset_pk, negotiation=negotiation)
+            except DRFValidationError as exc:
+                # e.g. a sell that exceeds holdings (partial history). Skip it and
+                # report it instead of aborting the whole import.
+                actions.append(
+                    {
+                        "code": code,
+                        "description": description,
+                        "action": "error",
+                        "reason": _validation_message(exc),
+                        "transaction": tx_payload,
+                    }
+                )
+                continue
+
             actions.append(
                 {
                     "code": code,
+                    "description": description,
                     "action": "transaction_created",
                     "asset_pk": asset_pk,
-                    "transaction": {
-                        "action": negotiation.action.value,
-                        "price": str(negotiation.price),
-                        "quantity": str(negotiation.quantity),
-                        "operation_date": negotiation.operation_date.isoformat(),
-                    },
+                    "transaction": tx_payload,
                 }
             )
 
@@ -617,11 +687,13 @@ def import_b3_renda_fixa_positions(
     use_posicao_price_when_missing_movement: bool = False,
     posicao_path: str | None = None,
     movimentacao_path: str | None = None,
+    workbook_dt: datetime | None = None,
 ) -> dict:
     return _run_with_rollback(
         user_id=user_id,
         dry_run=dry_run,
         posicao_path=posicao_path,
+        workbook_dt=workbook_dt,
         pipelines=[
             _make_renda_fixa_pipeline(
                 movimentacao_path=movimentacao_path,
@@ -637,11 +709,13 @@ def import_b3_tesouro_positions(
     dry_run: bool = True,
     posicao_path: str | None = None,
     movimentacao_path: str | None = None,
+    workbook_dt: datetime | None = None,
 ) -> dict:
     return _run_with_rollback(
         user_id=user_id,
         dry_run=dry_run,
         posicao_path=posicao_path,
+        workbook_dt=workbook_dt,
         pipelines=[_make_tesouro_pipeline(movimentacao_path=movimentacao_path)],
     )
 
@@ -674,8 +748,8 @@ def import_b3_negociacoes(
 
     return {
         "dry_run": dry_run,
-        "negociacao_path": str(negociacao_resolved),
-        "posicao_path": str(posicao_resolved) if posicao_resolved else None,
+        "negociacao_path": _source_label(negociacao_resolved),
+        "posicao_path": _source_label(posicao_resolved),
         "actions": actions,
     }
 
@@ -687,11 +761,13 @@ def import_b3_fixed_income_positions(
     use_posicao_price_when_missing_movement: bool = False,
     posicao_path: str | None = None,
     movimentacao_path: str | None = None,
+    workbook_dt: datetime | None = None,
 ) -> dict:
     return _run_with_rollback(
         user_id=user_id,
         dry_run=dry_run,
         posicao_path=posicao_path,
+        workbook_dt=workbook_dt,
         pipelines=[
             _make_renda_fixa_pipeline(
                 movimentacao_path=movimentacao_path,

--- a/django/variable_income_assets/integrations/b3/import_service.py
+++ b/django/variable_income_assets/integrations/b3/import_service.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import zipfile
+from datetime import datetime
+
+from django.core.files.uploadedfile import UploadedFile
+from django.db import transaction as djtransaction
+
+from openpyxl.utils.exceptions import InvalidFileException
+from rest_framework.exceptions import ValidationError as DRFValidationError
+
+from .handlers import (
+    B3ImportError,
+    import_b3_negociacoes,
+    import_b3_renda_fixa_positions,
+    import_b3_tesouro_positions,
+)
+from .parser import B3ParserError
+
+# Raised when an upload cannot be parsed/imported — surfaced to the client as a
+# 400 attributed to the failing operation. BadZipFile / InvalidFileException
+# cover a corrupt or non-xlsx payload reaching openpyxl.
+_OPERATION_ERRORS = (B3ParserError, B3ImportError, zipfile.BadZipFile, InvalidFileException)
+
+
+class B3ImportOperationError(Exception):
+    """A single B3 operation failed while parsing/running its files."""
+
+    def __init__(self, *, operation: str, detail: str) -> None:
+        self.operation = operation
+        self.detail = detail
+        super().__init__(f"{operation}: {detail}")
+
+    def as_dict(self) -> dict:
+        return {"operation": self.operation, "detail": self.detail}
+
+
+def _read(uploaded_file: UploadedFile | None) -> bytes | None:
+    return uploaded_file.read() if uploaded_file is not None else None
+
+
+def _format_drf_error(exc: DRFValidationError) -> str:
+    # Flatten a DRF/domain ValidationError to a single readable message (drops the
+    # field names, which are internal — e.g. "action" for a sell-exceeds-holdings).
+    detail = exc.detail
+    if isinstance(detail, dict):
+        messages: list = []
+        for value in detail.values():
+            messages.extend(value if isinstance(value, list | tuple) else [value])
+        return "; ".join(str(m) for m in messages)
+    if isinstance(detail, list | tuple):
+        return "; ".join(str(m) for m in detail)
+    return str(detail)
+
+
+def _run_operation(
+    operation: str,
+    *,
+    user_id: int,
+    dry_run: bool,
+    workbook_dt: datetime | None,
+    create_missing_assets: bool,
+    negociacao: bytes | None,
+    posicao: bytes | None,
+    movimentacao: bytes | None,
+) -> dict:
+    if operation == "negociacoes":
+        return import_b3_negociacoes(
+            user_id=user_id,
+            dry_run=dry_run,
+            create_missing_assets=create_missing_assets,
+            negociacao_path=negociacao,
+            posicao_path=posicao,
+        )
+    if operation == "renda_fixa":
+        return import_b3_renda_fixa_positions(
+            user_id=user_id,
+            dry_run=dry_run,
+            posicao_path=posicao,
+            movimentacao_path=movimentacao,
+            workbook_dt=workbook_dt,
+        )
+    return import_b3_tesouro_positions(
+        user_id=user_id,
+        dry_run=dry_run,
+        posicao_path=posicao,
+        movimentacao_path=movimentacao,
+        workbook_dt=workbook_dt,
+    )
+
+
+def run_b3_import(
+    *,
+    user_id: int,
+    operations: list[str],
+    dry_run: bool,
+    workbook_dt: datetime | None,
+    create_missing_assets: bool = False,
+    negociacao_file: UploadedFile | None,
+    posicao_file: UploadedFile | None,
+    movimentacao_file: UploadedFile | None,
+) -> dict:
+    files = {
+        "negociacao": _read(negociacao_file),
+        "posicao": _read(posicao_file),
+        "movimentacao": _read(movimentacao_file),
+    }
+
+    def run_all() -> dict:
+        reports: dict = {}
+        for operation in operations:
+            try:
+                reports[operation] = _run_operation(
+                    operation,
+                    user_id=user_id,
+                    dry_run=dry_run,
+                    workbook_dt=workbook_dt,
+                    create_missing_assets=create_missing_assets,
+                    **files,
+                )
+            except _OPERATION_ERRORS as exc:
+                raise B3ImportOperationError(operation=operation, detail=str(exc)) from exc
+            except DRFValidationError as exc:
+                # Domain rule violation (e.g. selling more than held) surfaced by a
+                # serializer; attribute it to the op so the client gets a clear 400.
+                raise B3ImportOperationError(
+                    operation=operation, detail=_format_drf_error(exc)
+                ) from exc
+        return reports
+
+    if dry_run:
+        # each handler self-rolls-back; the first op error aborts the whole preview
+        return {"dry_run": dry_run, "reports": run_all()}
+
+    with djtransaction.atomic():  # all-or-nothing across ops on apply
+        return {"dry_run": dry_run, "reports": run_all()}

--- a/django/variable_income_assets/integrations/b3/movimentacao.py
+++ b/django/variable_income_assets/integrations/b3/movimentacao.py
@@ -2,8 +2,7 @@ from datetime import date, datetime
 from decimal import Decimal, InvalidOperation
 from pathlib import Path
 
-from openpyxl import load_workbook
-
+from ._workbook import WorkbookSource, open_workbook
 from .parser import PROJECT_ROOT, B3ParserError
 from .schemas import B3FixedIncomeAction, B3FixedIncomeKind, B3FixedIncomeMovement
 
@@ -23,9 +22,11 @@ REQUIRED_HEADERS = (
 )
 
 
-def _resolve_path(path: str | None) -> Path:
-    if path is not None:
-        return Path(path)
+def _resolve_path(source: WorkbookSource | None) -> WorkbookSource:
+    if isinstance(source, bytes):
+        return source
+    if source is not None:
+        return Path(source)
 
     candidates = sorted(
         PROJECT_ROOT.glob(GLOB_PATTERN), key=lambda p: p.stat().st_mtime, reverse=True
@@ -38,9 +39,7 @@ def _resolve_path(path: str | None) -> Path:
 def _is_blank(value) -> bool:
     if value is None:
         return True
-    if isinstance(value, str) and value.strip() in ("", "-"):
-        return True
-    return False
+    return bool(isinstance(value, str) and value.strip() in ("", "-"))
 
 
 def _to_required_str(value, *, column: str, row_index: int) -> str:
@@ -103,12 +102,11 @@ def _build_header_index(header_row: tuple) -> dict[str, int]:
     return index
 
 
-def parse_movements(path: str | None = None) -> list[B3FixedIncomeMovement]:
-    resolved = _resolve_path(path)
-    workbook = load_workbook(resolved, data_only=True)
+def parse_movements(path: WorkbookSource | None = None) -> list[B3FixedIncomeMovement]:
+    workbook = open_workbook(_resolve_path(path))
     try:
         if SHEET_NAME not in workbook.sheetnames:
-            raise B3ParserError(f"sheet {SHEET_NAME!r} not found in {resolved}")
+            raise B3ParserError(f"sheet {SHEET_NAME!r} not found")
 
         sheet = workbook[SHEET_NAME]
         rows = sheet.iter_rows(values_only=True)

--- a/django/variable_income_assets/integrations/b3/negociacao.py
+++ b/django/variable_income_assets/integrations/b3/negociacao.py
@@ -2,8 +2,7 @@ from datetime import date, datetime
 from decimal import Decimal, InvalidOperation
 from pathlib import Path
 
-from openpyxl import load_workbook
-
+from ._workbook import WorkbookSource, open_workbook
 from .parser import PROJECT_ROOT, B3ParserError
 from .schemas import B3FixedIncomeAction, B3StockNegotiation, B3StockPosition
 
@@ -35,9 +34,11 @@ NEGOCIACAO_REQUIRED_HEADERS = (
 )
 
 
-def resolve_negociacao_path(path: str | None) -> Path:
-    if path is not None:
-        return Path(path)
+def resolve_negociacao_path(source: WorkbookSource | None) -> WorkbookSource:
+    if isinstance(source, bytes):
+        return source
+    if source is not None:
+        return Path(source)
     candidates = sorted(
         PROJECT_ROOT.glob(NEGOCIACAO_GLOB_PATTERN),
         key=lambda p: p.stat().st_mtime,
@@ -116,13 +117,12 @@ def _build_header_index(header_row: tuple, *, required: tuple[str, ...]) -> dict
 
 
 def _parse_positions_sheet(
-    path: str, *, sheet_name: str, asset_type: str
+    path: WorkbookSource, *, sheet_name: str, asset_type: str
 ) -> list[B3StockPosition]:
-    resolved = Path(path)
-    workbook = load_workbook(resolved, data_only=True)
+    workbook = open_workbook(path)
     try:
         if sheet_name not in workbook.sheetnames:
-            raise B3ParserError(f"sheet {sheet_name!r} not found in {resolved}")
+            raise B3ParserError(f"sheet {sheet_name!r} not found")
 
         sheet = workbook[sheet_name]
         rows = sheet.iter_rows(values_only=True)
@@ -162,20 +162,19 @@ def _parse_positions_sheet(
         workbook.close()
 
 
-def parse_stock_positions(path: str, *, asset_type: str) -> list[B3StockPosition]:
+def parse_stock_positions(path: WorkbookSource, *, asset_type: str) -> list[B3StockPosition]:
     return _parse_positions_sheet(path, sheet_name=ACOES_SHEET, asset_type=asset_type)
 
 
-def parse_fii_positions(path: str, *, asset_type: str) -> list[B3StockPosition]:
+def parse_fii_positions(path: WorkbookSource, *, asset_type: str) -> list[B3StockPosition]:
     return _parse_positions_sheet(path, sheet_name=FII_SHEET, asset_type=asset_type)
 
 
-def parse_negotiations(path: str) -> list[B3StockNegotiation]:
-    resolved = Path(path)
-    workbook = load_workbook(resolved, data_only=True)
+def parse_negotiations(path: WorkbookSource) -> list[B3StockNegotiation]:
+    workbook = open_workbook(path)
     try:
         if NEGOCIACAO_SHEET not in workbook.sheetnames:
-            raise B3ParserError(f"sheet {NEGOCIACAO_SHEET!r} not found in {resolved}")
+            raise B3ParserError(f"sheet {NEGOCIACAO_SHEET!r} not found")
 
         sheet = workbook[NEGOCIACAO_SHEET]
         rows = sheet.iter_rows(values_only=True)

--- a/django/variable_income_assets/integrations/b3/parser.py
+++ b/django/variable_income_assets/integrations/b3/parser.py
@@ -3,8 +3,7 @@ from datetime import date, datetime
 from decimal import Decimal, InvalidOperation
 from pathlib import Path
 
-from openpyxl import load_workbook
-
+from ._workbook import WorkbookSource, open_workbook
 from .schemas import B3FixedIncomeKind, B3FixedIncomePosition
 
 logger = logging.getLogger(__name__)
@@ -29,7 +28,9 @@ class B3ParserError(Exception):
     pass
 
 
-def _resolve_path(path: str | None) -> Path:
+def _resolve_path(path: WorkbookSource | None) -> WorkbookSource:
+    if isinstance(path, bytes):
+        return path
     if path is not None:
         return Path(path)
 
@@ -44,9 +45,7 @@ def _resolve_path(path: str | None) -> Path:
 def _is_blank(value) -> bool:
     if value is None:
         return True
-    if isinstance(value, str) and value.strip() in ("", "-"):
-        return True
-    return False
+    return bool(isinstance(value, str) and value.strip() in ("", "-"))
 
 
 def _to_optional_str(value) -> str | None:
@@ -118,12 +117,11 @@ def _build_header_index(header_row: tuple) -> dict[str, int]:
     return index
 
 
-def parse_positions(path: str | None = None) -> list[B3FixedIncomePosition]:
-    resolved = _resolve_path(path)
-    workbook = load_workbook(resolved, data_only=True)
+def parse_positions(path: WorkbookSource | None = None) -> list[B3FixedIncomePosition]:
+    workbook = open_workbook(_resolve_path(path))
     try:
         if SHEET_NAME not in workbook.sheetnames:
-            raise B3ParserError(f"sheet {SHEET_NAME!r} not found in {resolved}")
+            raise B3ParserError(f"sheet {SHEET_NAME!r} not found")
 
         sheet = workbook[SHEET_NAME]
         rows = sheet.iter_rows(values_only=True)

--- a/django/variable_income_assets/integrations/b3/schemas.py
+++ b/django/variable_income_assets/integrations/b3/schemas.py
@@ -1,8 +1,11 @@
 from datetime import date
-from decimal import Decimal
+from decimal import ROUND_HALF_UP, Decimal
 from enum import StrEnum
 
 from pydantic import BaseModel, ConfigDict
+
+# AssetMetaData.current_price is DecimalField(decimal_places=10).
+_PRICE_QUANTUM = Decimal("1.0000000000")
 
 
 class B3FixedIncomeKind(StrEnum):
@@ -56,7 +59,9 @@ class B3TesouroPosition(BaseModel):
     def current_price(self) -> Decimal | None:
         if self.current_value is None or self.quantity == 0:
             return None
-        return self.current_value / self.quantity
+        return (self.current_value / self.quantity).quantize(
+            _PRICE_QUANTUM, rounding=ROUND_HALF_UP
+        )
 
 
 class B3TesouroMovement(BaseModel):

--- a/django/variable_income_assets/integrations/b3/tesouro.py
+++ b/django/variable_income_assets/integrations/b3/tesouro.py
@@ -1,9 +1,7 @@
 from datetime import date, datetime
 from decimal import Decimal, InvalidOperation
-from pathlib import Path
 
-from openpyxl import load_workbook
-
+from ._workbook import WorkbookSource, open_workbook
 from .parser import B3ParserError
 from .schemas import B3FixedIncomeAction, B3TesouroMovement, B3TesouroPosition
 
@@ -38,9 +36,7 @@ MOVIMENTACAO_REQUIRED_HEADERS = (
 def _is_blank(value) -> bool:
     if value is None:
         return True
-    if isinstance(value, str) and value.strip() in ("", "-"):
-        return True
-    return False
+    return bool(isinstance(value, str) and value.strip() in ("", "-"))
 
 
 def _to_optional_str(value) -> str | None:
@@ -117,12 +113,11 @@ def _build_header_index(header_row: tuple, *, required: tuple[str, ...]) -> dict
     return index
 
 
-def parse_tesouro_positions(path: str) -> list[B3TesouroPosition]:
-    resolved = Path(path)
-    workbook = load_workbook(resolved, data_only=True)
+def parse_tesouro_positions(source: WorkbookSource) -> list[B3TesouroPosition]:
+    workbook = open_workbook(source)
     try:
         if POSICAO_SHEET not in workbook.sheetnames:
-            raise B3ParserError(f"sheet {POSICAO_SHEET!r} not found in {resolved}")
+            raise B3ParserError(f"sheet {POSICAO_SHEET!r} not found")
 
         sheet = workbook[POSICAO_SHEET]
         rows = sheet.iter_rows(values_only=True)
@@ -167,12 +162,11 @@ def parse_tesouro_positions(path: str) -> list[B3TesouroPosition]:
         workbook.close()
 
 
-def parse_tesouro_movements(path: str) -> list[B3TesouroMovement]:
-    resolved = Path(path)
-    workbook = load_workbook(resolved, data_only=True)
+def parse_tesouro_movements(source: WorkbookSource) -> list[B3TesouroMovement]:
+    workbook = open_workbook(source)
     try:
         if MOVIMENTACAO_SHEET not in workbook.sheetnames:
-            raise B3ParserError(f"sheet {MOVIMENTACAO_SHEET!r} not found in {resolved}")
+            raise B3ParserError(f"sheet {MOVIMENTACAO_SHEET!r} not found")
 
         sheet = workbook[MOVIMENTACAO_SHEET]
         rows = sheet.iter_rows(values_only=True)

--- a/django/variable_income_assets/integrations/b3/tests/test_b3_tesouro.py
+++ b/django/variable_income_assets/integrations/b3/tests/test_b3_tesouro.py
@@ -110,7 +110,8 @@ def test_happy_path_parses_tesouro_positions(tmp_path):
     assert ipca.maturity_date == date(2032, 8, 15)
     assert ipca.quantity == Decimal("15.48")
     assert ipca.current_value == Decimal("45390.59")
-    assert ipca.current_price == Decimal("45390.59") / Decimal("15.48")
+    # current_price is quantized to AssetMetaData's 10 decimal places.
+    assert ipca.current_price == Decimal("2932.2086563307")
 
 
 def test_position_blank_and_total_rows_are_skipped(tmp_path):

--- a/django/variable_income_assets/serializers.py
+++ b/django/variable_income_assets/serializers.py
@@ -1,5 +1,6 @@
 from decimal import ROUND_HALF_UP, Decimal, DecimalException
 
+from django.core.validators import FileExtensionValidator
 from django.utils import timezone
 
 from rest_framework import serializers
@@ -651,3 +652,70 @@ class AssetOperationPeriodSerializer(serializers.Serializer):
     started_at = serializers.DateField()
     closed_at = serializers.DateField(allow_null=True)
     roi = serializers.DecimalField(max_digits=20, decimal_places=4, allow_null=True)
+
+
+B3_IMPORT_OPERATIONS = ("negociacoes", "renda_fixa", "tesouro")
+B3_MAX_UPLOAD_BYTES = 10 * 1024 * 1024  # 10 MB
+
+
+class B3ImportSerializer(serializers.Serializer):
+    operations = serializers.ListField(
+        child=serializers.ChoiceField(choices=B3_IMPORT_OPERATIONS), allow_empty=False
+    )
+    dry_run = serializers.BooleanField()
+    create_missing_assets = serializers.BooleanField(required=False, default=False)
+    workbook_dt = serializers.DateTimeField(required=False, allow_null=True)
+    negociacao = serializers.FileField(
+        required=False,
+        allow_null=True,
+        validators=[FileExtensionValidator(allowed_extensions=["xlsx"])],
+    )
+    posicao = serializers.FileField(
+        required=False,
+        allow_null=True,
+        validators=[FileExtensionValidator(allowed_extensions=["xlsx"])],
+    )
+    movimentacao = serializers.FileField(
+        required=False,
+        allow_null=True,
+        validators=[FileExtensionValidator(allowed_extensions=["xlsx"])],
+    )
+
+    def validate(self, attrs: dict) -> dict:
+        ops = set(attrs["operations"])
+        negociacao = attrs.get("negociacao")
+        posicao = attrs.get("posicao")
+        movimentacao = attrs.get("movimentacao")
+
+        for field_name, file in (
+            ("negociacao", negociacao),
+            ("posicao", posicao),
+            ("movimentacao", movimentacao),
+        ):
+            # Extension is validated by FileExtensionValidator on the field; content is
+            # validated by openpyxl downstream. Here we only cap the size before reading.
+            if file is not None and file.size > B3_MAX_UPLOAD_BYTES:
+                raise serializers.ValidationError({field_name: "Arquivo muito grande (máx. 10 MB)"})
+
+        errors: dict = {}
+        if "negociacoes" in ops and negociacao is None:
+            errors["negociacao"] = "Necessário para importar negociações"
+        if attrs.get("create_missing_assets") and posicao is None:
+            errors["posicao"] = "Necessário para criar ativos ausentes"
+        if ops & {"renda_fixa", "tesouro"}:
+            if posicao is None:
+                errors["posicao"] = "Necessário para Renda Fixa / Tesouro"
+            if movimentacao is None:
+                errors["movimentacao"] = "Necessário para Renda Fixa / Tesouro"
+            if attrs.get("workbook_dt") is None:
+                errors["workbook_dt"] = "Necessário para Renda Fixa / Tesouro"
+        if errors:
+            raise serializers.ValidationError(errors)
+        return attrs
+
+
+class B3ImportResultSerializer(serializers.Serializer):
+    dry_run = serializers.BooleanField()
+    # reports maps each requested operation -> that handler's report dict
+    # (heterogeneous, already JSON-serializable); passed through as-is.
+    reports = serializers.DictField()

--- a/django/variable_income_assets/tests/integrations/test__b3_handlers.py
+++ b/django/variable_income_assets/tests/integrations/test__b3_handlers.py
@@ -221,7 +221,7 @@ def test_missing_asset_without_movimentacao_is_skipped_by_default(tmp_path, user
     )
 
     assert report["actions"][0]["action"] == "skipped"
-    assert "no movimentação" in report["actions"][0]["reason"]
+    assert "sem linha de movimentação" in report["actions"][0]["reason"]
     assert not Asset.objects.filter(user=user, code="CDB426DGCVL").exists()
 
 
@@ -398,7 +398,7 @@ def test_missing_td_asset_without_movimentacao_is_skipped(tmp_path, user):
     )
 
     assert report["actions"][0]["action"] == "skipped"
-    assert "no movimentação" in report["actions"][0]["reason"]
+    assert "sem linha de movimentação" in report["actions"][0]["reason"]
     assert not Asset.objects.filter(user=user, code="BRSTNCNTB7T1").exists()
 
 
@@ -441,7 +441,7 @@ def test_negociacao_skips_when_asset_not_in_db(tmp_path, user):
     )
 
     assert report["actions"][0]["action"] == "skipped"
-    assert "asset not in DB" in report["actions"][0]["reason"]
+    assert "ativo não cadastrado" in report["actions"][0]["reason"]
     assert not Transaction.objects.filter(asset__user=user).exists()
 
 
@@ -498,7 +498,7 @@ def test_negociacao_skips_when_missing_and_no_posicao(tmp_path, user):
     )
 
     assert report["actions"][0]["action"] == "skipped"
-    assert "create_missing_assets" in report["actions"][0]["reason"]
+    assert "Criar ativos ausentes" in report["actions"][0]["reason"]
 
 
 def test_negociacao_dry_run_rolls_back(tmp_path, user):
@@ -539,3 +539,78 @@ def test_invalid_posicao_filename_raises(tmp_path, user):
             posicao_path=str(bad),
             movimentacao_path=movimentacao_path,
         )
+
+
+def _neg_row(*, date: str, action: str, code: str, qty, price):
+    return [
+        date, action, "Mercado à Vista", "-", "INTER DTVM",
+        code, qty, price, float(qty) * float(price),
+    ]
+
+
+def test_negociacoes_applied_chronologically_when_file_is_descending(tmp_path, user):
+    # Existing asset with no holdings; the file lists the SELL (later date) BEFORE
+    # the BUY (earlier date), as B3 reports do (most-recent-first). Without
+    # chronological ordering the domain would reject the sell.
+    AssetFactory(
+        code="BBAS3", type=AssetTypes.stock, currency=Currencies.real,
+        objective=AssetObjectives.growth, user=user,
+    )
+    AssetMetaDataFactory(
+        code="BBAS3", type=AssetTypes.stock, currency=Currencies.real,
+        current_price=Decimal("21.71"), current_price_updated_at=timezone.now(),
+    )
+    from ...management.commands.sync_assets_cqrs import Command as Sync
+
+    Sync().handle(user_ids=[user.id])
+
+    negociacao_path = _build_negociacao(
+        tmp_path,
+        [
+            _neg_row(date="05/04/2026", action="Venda", code="BBAS3", qty=50, price=25),
+            _neg_row(date="01/04/2026", action="Compra", code="BBAS3", qty=100, price=20),
+        ],
+    )
+
+    report = import_b3_negociacoes(
+        user_id=user.id, dry_run=False, negociacao_path=negociacao_path
+    )
+
+    created = [a for a in report["actions"] if a["action"] == "transaction_created"]
+    assert len(created) == 2
+    assert (
+        Transaction.objects.filter(asset__user=user, asset__code="BBAS3").count() == 2
+    )
+
+
+def test_negociacoes_oversell_is_reported_not_aborted(tmp_path, user):
+    # Existing asset with no holdings; the file has only a SELL (partial history).
+    # The domain rejects it, but the import must report it as an error and keep
+    # going, not abort the whole run.
+    AssetFactory(
+        code="BBAS3", type=AssetTypes.stock, currency=Currencies.real,
+        objective=AssetObjectives.growth, user=user,
+    )
+    AssetMetaDataFactory(
+        code="BBAS3", type=AssetTypes.stock, currency=Currencies.real,
+        current_price=Decimal("21.71"), current_price_updated_at=timezone.now(),
+    )
+    from ...management.commands.sync_assets_cqrs import Command as Sync
+
+    Sync().handle(user_ids=[user.id])
+
+    negociacao_path = _build_negociacao(
+        tmp_path,
+        [_neg_row(date="01/04/2026", action="Venda", code="BBAS3", qty=10, price=20)],
+    )
+
+    report = import_b3_negociacoes(
+        user_id=user.id, dry_run=False, negociacao_path=negociacao_path
+    )
+
+    errors = [a for a in report["actions"] if a["action"] == "error"]
+    assert len(errors) == 1
+    assert "vender" in errors[0]["reason"].lower()
+    assert not Transaction.objects.filter(
+        asset__user=user, asset__code="BBAS3"
+    ).exists()

--- a/django/variable_income_assets/tests/integrations/test__b3_import_api.py
+++ b/django/variable_income_assets/tests/integrations/test__b3_import_api.py
@@ -1,0 +1,297 @@
+from datetime import timedelta
+from decimal import Decimal
+
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.utils import timezone
+
+import pytest
+from rest_framework.test import APIClient
+
+from config.settings.base import BASE_API_URL
+from variable_income_assets.integrations.b3.handlers import (
+    import_b3_renda_fixa_positions,
+)
+from variable_income_assets.models import Asset, AssetMetaData, Transaction
+from variable_income_assets.tests.integrations.test__b3_handlers import (
+    WORKBOOK_DT,
+    _build_movimentacao,
+    _build_posicao,
+    _cdb_movimentacao_row,
+    _cdb_position_row,
+    fixed_br_asset,  # noqa: F401  -- re-exported pytest fixture
+)
+
+pytestmark = pytest.mark.django_db
+
+B3_IMPORT_URL = f"/{BASE_API_URL}assets/b3_import"
+
+
+def test_renda_fixa_handler_is_exported():
+    from variable_income_assets.integrations import b3
+
+    assert hasattr(b3, "import_b3_renda_fixa_positions")
+    assert "import_b3_renda_fixa_positions" in b3.__all__
+
+
+def test_dry_run_does_not_write_price_metadata(tmp_path, user, fixed_br_asset):
+    posicao_path = _build_posicao(tmp_path, [_cdb_position_row()])
+    movimentacao_path = _build_movimentacao(tmp_path, [])
+
+    report = import_b3_renda_fixa_positions(
+        user_id=user.id,
+        dry_run=True,
+        posicao_path=posicao_path,
+        movimentacao_path=movimentacao_path,
+    )
+
+    # action is still reported...
+    assert report["actions"][0]["action"] == "price_updated"
+    # ...but the metadata row was NOT mutated on a dry run
+    metadata = AssetMetaData.objects.get(code="CDB426DGCVL")
+    assert metadata.current_price == Decimal("1000")  # unchanged stale value
+
+
+def test_explicit_workbook_dt_overrides_filename(tmp_path, user, fixed_br_asset):
+    # fixed_br_asset metadata was updated at WORKBOOK_DT - 1 day.
+    # Pass an explicit workbook_dt OLDER than the metadata -> price must be skipped,
+    # proving the explicit value (not the filename's 2026-04-29) is used.
+    posicao_path = _build_posicao(tmp_path, [_cdb_position_row()])
+    movimentacao_path = _build_movimentacao(tmp_path, [])
+    older_dt = timezone.make_aware(WORKBOOK_DT - timedelta(days=10))
+
+    report = import_b3_renda_fixa_positions(
+        user_id=user.id,
+        dry_run=False,
+        posicao_path=posicao_path,
+        movimentacao_path=movimentacao_path,
+        workbook_dt=older_dt,
+    )
+
+    assert report["actions"][0]["action"] == "price_skipped"
+    assert report["workbook_dt"] == older_dt.isoformat()
+
+
+# --- Task 4: B3ImportSerializer -------------------------------------------------
+
+
+def _xlsx_upload(name: str) -> SimpleUploadedFile:
+    return SimpleUploadedFile(
+        name,
+        b"PK\x03\x04fake-xlsx-bytes",
+        content_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    )
+
+
+def test_serializer_requires_at_least_one_operation():
+    from variable_income_assets.serializers import B3ImportSerializer
+
+    serializer = B3ImportSerializer(data={"operations": [], "dry_run": True})
+    assert not serializer.is_valid()
+    assert "operations" in serializer.errors
+
+
+def test_serializer_negociacoes_requires_negociacao_file():
+    from variable_income_assets.serializers import B3ImportSerializer
+
+    serializer = B3ImportSerializer(
+        data={"operations": ["negociacoes"], "dry_run": True}
+    )
+    assert not serializer.is_valid()
+    assert "negociacao" in str(serializer.errors)
+
+
+def test_serializer_renda_fixa_requires_posicao_movimentacao_and_workbook_dt():
+    from variable_income_assets.serializers import B3ImportSerializer
+
+    serializer = B3ImportSerializer(
+        data={
+            "operations": ["renda_fixa"],
+            "dry_run": True,
+            "posicao": _xlsx_upload("posicao-2026-04-29-12-00-00.xlsx"),
+        }
+    )
+    assert not serializer.is_valid()
+    errors = str(serializer.errors)
+    assert "movimentacao" in errors
+    assert "workbook_dt" in errors
+
+
+def test_serializer_rejects_non_xlsx_extension():
+    from variable_income_assets.serializers import B3ImportSerializer
+
+    serializer = B3ImportSerializer(
+        data={
+            "operations": ["negociacoes"],
+            "dry_run": True,
+            "negociacao": _xlsx_upload("trades.csv"),
+        }
+    )
+    assert not serializer.is_valid()
+    assert "negociacao" in serializer.errors
+
+
+def test_serializer_valid_negociacoes():
+    from variable_income_assets.serializers import B3ImportSerializer
+
+    serializer = B3ImportSerializer(
+        data={
+            "operations": ["negociacoes"],
+            "dry_run": True,
+            "negociacao": _xlsx_upload("negociacao.xlsx"),
+        }
+    )
+    assert serializer.is_valid(), serializer.errors
+
+
+def test_serializer_create_missing_assets_requires_posicao():
+    from variable_income_assets.serializers import B3ImportSerializer
+
+    serializer = B3ImportSerializer(
+        data={
+            "operations": ["negociacoes"],
+            "dry_run": True,
+            "create_missing_assets": True,
+            "negociacao": _xlsx_upload("negociacao.xlsx"),
+        }
+    )
+    assert not serializer.is_valid()
+    assert "posicao" in serializer.errors
+
+
+# --- Task 5: run_b3_import service ---------------------------------------------
+
+
+def _upload_from_path(path: str, name: str) -> SimpleUploadedFile:
+    with open(path, "rb") as fh:
+        return SimpleUploadedFile(name, fh.read())
+
+
+def test_service_dry_run_writes_nothing(tmp_path, user, sync_assets_read_model):
+    from variable_income_assets.integrations.b3.import_service import run_b3_import
+
+    posicao = _upload_from_path(
+        _build_posicao(tmp_path, [_cdb_position_row()]), "posicao-2026-04-29-12-00-00.xlsx"
+    )
+    movimentacao = _upload_from_path(
+        _build_movimentacao(tmp_path, [_cdb_movimentacao_row()]), "movimentacao.xlsx"
+    )
+
+    result = run_b3_import(
+        user_id=user.id,
+        operations=["renda_fixa"],
+        dry_run=True,
+        workbook_dt=timezone.make_aware(WORKBOOK_DT),
+        negociacao_file=None,
+        posicao_file=posicao,
+        movimentacao_file=movimentacao,
+    )
+
+    assert result["dry_run"] is True
+    assert result["reports"]["renda_fixa"]["actions"][0]["action"] == "created"
+    assert not Asset.objects.filter(user=user, code="CDB426DGCVL").exists()  # rolled back
+
+
+def test_service_apply_writes(tmp_path, user, sync_assets_read_model):
+    from variable_income_assets.integrations.b3.import_service import run_b3_import
+
+    posicao = _upload_from_path(
+        _build_posicao(tmp_path, [_cdb_position_row()]), "posicao-2026-04-29-12-00-00.xlsx"
+    )
+    movimentacao = _upload_from_path(
+        _build_movimentacao(tmp_path, [_cdb_movimentacao_row()]), "movimentacao.xlsx"
+    )
+
+    run_b3_import(
+        user_id=user.id,
+        operations=["renda_fixa"],
+        dry_run=False,
+        workbook_dt=timezone.make_aware(WORKBOOK_DT),
+        negociacao_file=None,
+        posicao_file=posicao,
+        movimentacao_file=movimentacao,
+    )
+
+    asset = Asset.objects.get(user=user, code="CDB426DGCVL")
+    assert Transaction.objects.filter(asset=asset).exists()
+
+
+def test_service_bad_file_raises_operation_error(tmp_path, user):
+    from variable_income_assets.integrations.b3.import_service import (
+        B3ImportOperationError,
+        run_b3_import,
+    )
+
+    bad = SimpleUploadedFile("posicao-2026-04-29-12-00-00.xlsx", b"not a real workbook")
+    movimentacao = SimpleUploadedFile("movimentacao.xlsx", b"not a real workbook")
+
+    with pytest.raises(B3ImportOperationError) as exc:
+        run_b3_import(
+            user_id=user.id,
+            operations=["tesouro"],
+            dry_run=True,
+            workbook_dt=timezone.make_aware(WORKBOOK_DT),
+            negociacao_file=None,
+            posicao_file=bad,
+            movimentacao_file=movimentacao,
+        )
+    assert exc.value.operation == "tesouro"
+
+
+# --- Task 6: POST /assets/b3_import endpoint -----------------------------------
+
+
+def test_endpoint_requires_authentication():
+    response = APIClient().post(
+        B3_IMPORT_URL, data={"operations": ["negociacoes"]}, format="multipart"
+    )
+    assert response.status_code == 401
+
+
+def test_endpoint_dry_run_returns_reports(client, user, tmp_path, sync_assets_read_model):
+    posicao_path = _build_posicao(tmp_path, [_cdb_position_row()])
+    movimentacao_path = _build_movimentacao(tmp_path, [_cdb_movimentacao_row()])
+
+    with open(posicao_path, "rb") as posicao, open(movimentacao_path, "rb") as movimentacao:
+        response = client.post(
+            B3_IMPORT_URL,
+            data={
+                "operations": ["renda_fixa"],
+                "dry_run": True,
+                "workbook_dt": timezone.make_aware(WORKBOOK_DT).isoformat(),
+                "posicao": posicao,
+                "movimentacao": movimentacao,
+            },
+            format="multipart",
+        )
+
+    assert response.status_code == 200, response.data
+    body = response.json()
+    assert body["dry_run"] is True
+    assert body["reports"]["renda_fixa"]["actions"][0]["action"] == "created"
+    assert not Asset.objects.filter(user=user, code="CDB426DGCVL").exists()
+
+
+def test_endpoint_validation_error_is_400(client):
+    response = client.post(
+        B3_IMPORT_URL, data={"operations": ["renda_fixa"], "dry_run": True}, format="multipart"
+    )
+    assert response.status_code == 400
+    assert "posicao" in str(response.data)
+
+
+def test_endpoint_bad_file_returns_400_with_operation(client):
+    bad = SimpleUploadedFile("posicao-2026-04-29-12-00-00.xlsx", b"not a workbook")
+    mov = SimpleUploadedFile("movimentacao.xlsx", b"not a workbook")
+    response = client.post(
+        B3_IMPORT_URL,
+        data={
+            "operations": ["tesouro"],
+            "dry_run": True,
+            "workbook_dt": timezone.make_aware(WORKBOOK_DT).isoformat(),
+            "posicao": bad,
+            "movimentacao": mov,
+        },
+        format="multipart",
+    )
+    assert response.status_code == 400
+    assert response.data["operation"] == "tesouro"

--- a/django/variable_income_assets/views.py
+++ b/django/variable_income_assets/views.py
@@ -19,8 +19,9 @@ from rest_framework.mixins import (
     ListModelMixin,
     UpdateModelMixin,
 )
+from rest_framework.parsers import FormParser, MultiPartParser
 from rest_framework.response import Response
-from rest_framework.status import HTTP_200_OK, HTTP_204_NO_CONTENT
+from rest_framework.status import HTTP_200_OK, HTTP_204_NO_CONTENT, HTTP_400_BAD_REQUEST
 from rest_framework.viewsets import GenericViewSet, ModelViewSet
 
 from shared.filters import PatrimonyGrowthFilterSet
@@ -34,6 +35,7 @@ from variable_income_assets.models.managers.write import AssetClosedOperationQue
 from . import choices, filters, serializers
 from .adapters.key_value_store import get_dollar_conversion_rate
 from .domain import events
+from .integrations.b3.import_service import B3ImportOperationError, run_b3_import
 from .models import (
     Asset,
     AssetClosedOperation,
@@ -135,6 +137,33 @@ class AssetViewSet(
             {**qs, "total_diff_percentage": total_diff_percentage}
         )
         return Response(serializer.data, status=HTTP_200_OK)
+
+    @action(
+        methods=("POST",),
+        detail=False,
+        url_path="b3_import",
+        parser_classes=(MultiPartParser, FormParser),
+    )
+    def b3_import(self, request: Request) -> Response:
+        serializer = serializers.B3ImportSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        data = serializer.validated_data
+        try:
+            result = run_b3_import(
+                user_id=request.user.id,
+                operations=data["operations"],
+                dry_run=data["dry_run"],
+                workbook_dt=data.get("workbook_dt"),
+                create_missing_assets=data.get("create_missing_assets", False),
+                negociacao_file=data.get("negociacao"),
+                posicao_file=data.get("posicao"),
+                movimentacao_file=data.get("movimentacao"),
+            )
+        except B3ImportOperationError as exc:
+            return Response(exc.as_dict(), status=HTTP_400_BAD_REQUEST)
+        return Response(
+            serializers.B3ImportResultSerializer(result).data, status=HTTP_200_OK
+        )
 
     @action(methods=("GET",), detail=False)
     def growth(self, request: Request) -> Response:

--- a/react/src/pages/private/Assets/ImportB3/B3ImportReport.tsx
+++ b/react/src/pages/private/Assets/ImportB3/B3ImportReport.tsx
@@ -1,0 +1,304 @@
+import { Fragment, useState } from "react";
+
+import CloseIcon from "@mui/icons-material/Close";
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
+import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
+import KeyboardArrowRightIcon from "@mui/icons-material/KeyboardArrowRight";
+import OpenInFullIcon from "@mui/icons-material/OpenInFull";
+import Accordion from "@mui/material/Accordion";
+import AccordionDetails from "@mui/material/AccordionDetails";
+import AccordionSummary from "@mui/material/AccordionSummary";
+import Box from "@mui/material/Box";
+import Chip from "@mui/material/Chip";
+import Drawer from "@mui/material/Drawer";
+import IconButton from "@mui/material/IconButton";
+import Stack from "@mui/material/Stack";
+import Table from "@mui/material/Table";
+import TableBody from "@mui/material/TableBody";
+import TableCell from "@mui/material/TableCell";
+import TableRow from "@mui/material/TableRow";
+import Typography from "@mui/material/Typography";
+
+import { Colors, getColor } from "../../../../design-system";
+import { priceDiffPct } from "./logic";
+import type {
+  B3ActionEntry,
+  B3ImportResponse,
+  B3Operation,
+  B3OperationReport,
+} from "./types";
+
+const OPERATION_LABELS: Record<B3Operation, string> = {
+  negociacoes: "Negociações",
+  renda_fixa: "Renda Fixa",
+  tesouro: "Tesouro",
+};
+
+const ACTION_LABELS: Record<string, string> = {
+  created: "Ativo criado",
+  asset_created: "Ativo criado",
+  transaction_created: "Transação criada",
+  price_updated: "Preço atualizado",
+  price_skipped: "Preço mantido",
+  skipped: "Ignorado",
+  error: "Erro",
+};
+
+// These chips label an outcome (not a status), so render them as outlined tags
+// tinted with design-system tokens: brand for things that happened, neutral for
+// no-ops, danger for failures.
+const COLOR_BY_ACTION: Record<string, Colors> = {
+  created: Colors.brand,
+  asset_created: Colors.brand,
+  transaction_created: Colors.brand,
+  price_updated: Colors.brand,
+  price_skipped: Colors.neutral300,
+  skipped: Colors.neutral300,
+  error: Colors.danger200,
+};
+
+const actionLabel = (action: string) => ACTION_LABELS[action] ?? action;
+
+const ActionChip = ({ action, label }: { action: string; label: string }) => {
+  const color = getColor(COLOR_BY_ACTION[action] ?? Colors.neutral300);
+  return (
+    <Chip
+      size="small"
+      variant="outlined"
+      label={label}
+      sx={{ borderColor: color, color }}
+    />
+  );
+};
+
+const detailText = (entry: B3ActionEntry): string => {
+  if (entry.action === "skipped") return entry.reason ?? "";
+  if (entry.action === "price_skipped") return entry.reason ?? "";
+  if (entry.action === "error") return entry.reason ?? "";
+  if (entry.action === "created" || entry.action === "asset_created")
+    return `#${entry.asset_pk ?? "—"}`;
+  return "";
+};
+
+const PriceUpdatedDetail = ({ entry }: { entry: B3ActionEntry }) => {
+  const pct = priceDiffPct(entry.previous_price, entry.new_price);
+  return (
+    <>
+      {entry.previous_price ?? "—"} → {entry.new_price ?? "—"}
+      {pct !== null && (
+        <Typography
+          component="span"
+          variant="body2"
+          sx={{
+            ml: 1,
+            color: getColor(pct >= 0 ? Colors.brand : Colors.danger200),
+          }}
+        >
+          ({pct >= 0 ? "+" : ""}
+          {pct.toFixed(2)}%)
+        </Typography>
+      )}
+    </>
+  );
+};
+
+const ActionRow = ({ entry }: { entry: B3ActionEntry }) => {
+  const [open, setOpen] = useState(false);
+  const subTransactions =
+    entry.transactions ?? (entry.transaction ? [entry.transaction] : []);
+  const expandable = subTransactions.length > 0;
+
+  return (
+    <Fragment>
+      <TableRow>
+        <TableCell padding="checkbox">
+          {expandable && (
+            <IconButton size="small" onClick={() => setOpen((v) => !v)}>
+              {open ? <KeyboardArrowDownIcon /> : <KeyboardArrowRightIcon />}
+            </IconButton>
+          )}
+        </TableCell>
+        <TableCell>
+          <Stack spacing={0}>
+            <span>{entry.code ?? "—"}</span>
+            {entry.description && (
+              <Typography variant="caption" color={getColor(Colors.neutral300)}>
+                {entry.description}
+              </Typography>
+            )}
+          </Stack>
+        </TableCell>
+        <TableCell>
+          <ActionChip action={entry.action} label={actionLabel(entry.action)} />
+        </TableCell>
+        <TableCell>
+          {entry.action === "price_updated" ? (
+            <PriceUpdatedDetail entry={entry} />
+          ) : (
+            detailText(entry)
+          )}
+        </TableCell>
+      </TableRow>
+      {open &&
+        subTransactions.map((tx, i) => (
+          <TableRow key={i}>
+            <TableCell />
+            <TableCell colSpan={3}>
+              <Typography variant="body2" color={getColor(Colors.neutral300)}>
+                {tx.action} {tx.quantity} @ {tx.price} em {tx.operation_date}
+              </Typography>
+            </TableCell>
+          </TableRow>
+        ))}
+    </Fragment>
+  );
+};
+
+const summaryChips = (actions: B3ActionEntry[]) => {
+  const counts: Record<string, number> = {};
+  actions.forEach((a) => {
+    counts[a.action] = (counts[a.action] ?? 0) + 1;
+  });
+  return Object.entries(counts).map(([action, count]) => (
+    <ActionChip
+      key={action}
+      action={action}
+      label={`${actionLabel(action)}: ${count}`}
+    />
+  ));
+};
+
+const StatusPill = ({ dryRun }: { dryRun: boolean }) => (
+  <Chip
+    size="small"
+    variant="outlined"
+    label={dryRun ? "PRÉ-VISUALIZAÇÃO" : "APLICADO"}
+    sx={{
+      borderColor: getColor(dryRun ? Colors.neutral300 : Colors.brand),
+      color: getColor(dryRun ? Colors.neutral300 : Colors.brand),
+    }}
+  />
+);
+
+const OperationContent = ({ report }: { report: B3OperationReport }) => (
+  <Stack spacing={1}>
+    <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
+      {summaryChips(report.actions)}
+      <Chip
+        size="small"
+        variant="outlined"
+        label={`Total: ${report.actions.length}`}
+        sx={{
+          borderColor: getColor(Colors.neutral300),
+          color: getColor(Colors.neutral300),
+        }}
+      />
+    </Stack>
+    {report.actions.length > 0 ? (
+      <Table size="small">
+        <TableBody>
+          {report.actions.map((entry, i) => (
+            <ActionRow key={i} entry={entry} />
+          ))}
+        </TableBody>
+      </Table>
+    ) : (
+      <Typography variant="body2" color={getColor(Colors.neutral300)}>
+        Nenhuma ação.
+      </Typography>
+    )}
+  </Stack>
+);
+
+const OperationSection = ({
+  op,
+  report,
+  onExpand,
+}: {
+  op: B3Operation;
+  report: B3OperationReport;
+  onExpand: () => void;
+}) => (
+  <Accordion defaultExpanded>
+    <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+      <Stack direction="row" spacing={1} alignItems="center" sx={{ flex: 1 }}>
+        <Typography>{OPERATION_LABELS[op]}</Typography>
+        <StatusPill dryRun={report.dry_run} />
+        <Box sx={{ flexGrow: 1 }} />
+        <IconButton
+          component="div"
+          role="button"
+          size="small"
+          aria-label="Expandir"
+          onClick={(e) => {
+            e.stopPropagation();
+            onExpand();
+          }}
+        >
+          <OpenInFullIcon fontSize="small" />
+        </IconButton>
+      </Stack>
+    </AccordionSummary>
+    <AccordionDetails>
+      <OperationContent report={report} />
+    </AccordionDetails>
+  </Accordion>
+);
+
+const B3ImportReport = ({ response }: { response: B3ImportResponse }) => {
+  const [expandedOp, setExpandedOp] = useState<B3Operation | null>(null);
+  const ops = (Object.keys(response.reports) as B3Operation[]).filter(
+    (op) => response.reports[op],
+  );
+  const expandedReport = expandedOp ? response.reports[expandedOp] : null;
+
+  return (
+    <>
+      <Stack spacing={1}>
+        {ops.map((op) => (
+          <OperationSection
+            key={op}
+            op={op}
+            report={response.reports[op]!}
+            onExpand={() => setExpandedOp(op)}
+          />
+        ))}
+      </Stack>
+      <Drawer
+        open={expandedOp !== null}
+        onClose={() => setExpandedOp(null)}
+        anchor="right"
+        slotProps={{
+          paper: {
+            sx: {
+              width: "90vw",
+              maxWidth: 1200,
+              backgroundColor: getColor(Colors.neutral600),
+              backgroundImage: "none",
+            },
+          },
+        }}
+      >
+        {expandedOp && expandedReport && (
+          <Stack spacing={2} sx={{ p: 3 }}>
+            <Stack direction="row" spacing={1} alignItems="center">
+              <Typography variant="h6">{OPERATION_LABELS[expandedOp]}</Typography>
+              <StatusPill dryRun={expandedReport.dry_run} />
+              <Box sx={{ flexGrow: 1 }} />
+              <IconButton
+                size="small"
+                aria-label="Fechar"
+                onClick={() => setExpandedOp(null)}
+              >
+                <CloseIcon />
+              </IconButton>
+            </Stack>
+            <OperationContent report={expandedReport} />
+          </Stack>
+        )}
+      </Drawer>
+    </>
+  );
+};
+
+export default B3ImportReport;

--- a/react/src/pages/private/Assets/ImportB3/FileDropArea.tsx
+++ b/react/src/pages/private/Assets/ImportB3/FileDropArea.tsx
@@ -1,0 +1,59 @@
+import { useState } from "react";
+
+import UploadFileIcon from "@mui/icons-material/UploadFile";
+import Box from "@mui/material/Box";
+import Typography from "@mui/material/Typography";
+
+import { Colors, getColor } from "../../../../design-system";
+
+const FileDropArea = ({ onFiles }: { onFiles: (files: FileList) => void }) => {
+  const [dragActive, setDragActive] = useState(false);
+
+  return (
+    <Box
+      component="label"
+      onDragOver={(e) => {
+        e.preventDefault();
+        setDragActive(true);
+      }}
+      onDragLeave={() => setDragActive(false)}
+      onDrop={(e) => {
+        e.preventDefault();
+        setDragActive(false);
+        if (e.dataTransfer.files.length) onFiles(e.dataTransfer.files);
+      }}
+      sx={{
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        gap: 1,
+        p: 3,
+        borderRadius: 2,
+        cursor: "pointer",
+        textAlign: "center",
+        border: `1px dashed ${getColor(dragActive ? Colors.brand : Colors.neutral400)}`,
+        backgroundColor: getColor(Colors.neutral700),
+      }}
+    >
+      <input
+        type="file"
+        accept=".xlsx"
+        multiple
+        hidden
+        onChange={(e) => {
+          if (e.target.files?.length) onFiles(e.target.files);
+          e.target.value = ""; // allow re-selecting the same files
+        }}
+      />
+      <UploadFileIcon />
+      <Typography variant="body2">
+        Arraste os arquivos da B3 aqui ou clique para selecionar
+      </Typography>
+      <Typography variant="caption" color={getColor(Colors.neutral300)}>
+        negociação, posição e/ou movimentação (.xlsx)
+      </Typography>
+    </Box>
+  );
+};
+
+export default FileDropArea;

--- a/react/src/pages/private/Assets/ImportB3/index.tsx
+++ b/react/src/pages/private/Assets/ImportB3/index.tsx
@@ -1,0 +1,340 @@
+import { useEffect, useMemo, useState } from "react";
+
+import CloseIcon from "@mui/icons-material/Close";
+import Button from "@mui/material/Button";
+import Checkbox from "@mui/material/Checkbox";
+import CircularProgress from "@mui/material/CircularProgress";
+import Divider from "@mui/material/Divider";
+import Drawer from "@mui/material/Drawer";
+import FormControlLabel from "@mui/material/FormControlLabel";
+import IconButton from "@mui/material/IconButton";
+import Stack from "@mui/material/Stack";
+import Switch from "@mui/material/Switch";
+import Typography from "@mui/material/Typography";
+import { AdapterDateFns } from "@mui/x-date-pickers/AdapterDateFnsV3";
+import { DateTimePicker } from "@mui/x-date-pickers/DateTimePicker";
+import { LocalizationProvider } from "@mui/x-date-pickers/LocalizationProvider";
+import { ptBR } from "date-fns/locale/pt-BR";
+
+import { useMutation } from "@tanstack/react-query";
+import { enqueueSnackbar } from "notistack";
+
+import { Colors, getColor } from "../../../../design-system";
+import { importB3 } from "../api";
+import B3ImportReport from "./B3ImportReport";
+import FileDropArea from "./FileDropArea";
+import {
+  classifyB3File,
+  computeSignature,
+  isCreateMissingEnabled,
+  isOperationEnabled,
+  parseWorkbookDtFromFilename,
+  type B3FileSlot,
+  type B3Files,
+} from "./logic";
+import type { B3ImportResponse, B3Operation } from "./types";
+
+const OPERATIONS: { op: B3Operation; label: string }[] = [
+  { op: "negociacoes", label: "Negociações" },
+  { op: "renda_fixa", label: "Renda Fixa" },
+  { op: "tesouro", label: "Tesouro" },
+];
+
+const SLOT_LABELS: { slot: B3FileSlot; label: string }[] = [
+  { slot: "negociacao", label: "Negociação" },
+  { slot: "posicao", label: "Posição" },
+  { slot: "movimentacao", label: "Movimentação" },
+];
+
+const EMPTY_FILES: B3Files = {
+  negociacao: null,
+  posicao: null,
+  movimentacao: null,
+};
+
+const B3ImportDrawer = ({
+  open,
+  onClose,
+}: {
+  open: boolean;
+  onClose: () => void;
+}) => {
+  const [files, setFiles] = useState<B3Files>(EMPTY_FILES);
+  const [unrecognized, setUnrecognized] = useState<string[]>([]);
+  const [selectedOps, setSelectedOps] = useState<B3Operation[]>([]);
+  const [workbookDt, setWorkbookDt] = useState<Date | null>(null);
+  const [createMissingAssets, setCreateMissingAssets] = useState(false);
+  const [dryRun, setDryRun] = useState(true);
+  const [report, setReport] = useState<B3ImportResponse | null>(null);
+  const [previewedSignature, setPreviewedSignature] = useState<string | null>(
+    null,
+  );
+
+  // When the file set changes, default to every operation those files enable
+  // (assume the user wants them all); they can still uncheck before running.
+  useEffect(() => {
+    setSelectedOps(
+      OPERATIONS.map(({ op }) => op).filter((op) => isOperationEnabled(op, files)),
+    );
+  }, [files]);
+
+  const createMissingEnabled = isCreateMissingEnabled(files, selectedOps);
+
+  // Uncheck "criar ativos ausentes" when it can no longer take effect.
+  useEffect(() => {
+    if (!createMissingEnabled) setCreateMissingAssets(false);
+  }, [createMissingEnabled]);
+
+  const currentSignature = useMemo(
+    () => computeSignature(files, selectedOps, workbookDt, createMissingAssets),
+    [files, selectedOps, workbookDt, createMissingAssets],
+  );
+
+  const needsWorkbookDt = selectedOps.some(
+    (op) => op === "renda_fixa" || op === "tesouro",
+  );
+
+  // Route a batch of dropped/selected files to their slots by filename.
+  const handleFiles = (fileList: FileList) => {
+    const next: B3Files = { ...files };
+    const unknown: string[] = [];
+    let posicaoFile: File | null = null;
+    Array.from(fileList).forEach((file) => {
+      const slot = classifyB3File(file.name);
+      if (slot) {
+        next[slot] = file;
+        if (slot === "posicao") posicaoFile = file;
+      } else {
+        unknown.push(file.name);
+      }
+    });
+    setFiles(next);
+    setUnrecognized(unknown);
+    if (posicaoFile) {
+      const parsed = parseWorkbookDtFromFilename((posicaoFile as File).name);
+      if (parsed) setWorkbookDt(parsed);
+    }
+  };
+
+  const clearSlot = (slot: B3FileSlot) =>
+    setFiles((prev) => ({ ...prev, [slot]: null }));
+
+  // Wipe everything once the drawer has finished sliding out (avoids a flash of
+  // cleared fields during the close animation).
+  const resetState = () => {
+    setFiles(EMPTY_FILES);
+    setUnrecognized([]);
+    setSelectedOps([]);
+    setWorkbookDt(null);
+    setCreateMissingAssets(false);
+    setDryRun(true);
+    setReport(null);
+    setPreviewedSignature(null);
+  };
+
+  const toggleOp = (op: B3Operation) =>
+    setSelectedOps((prev) =>
+      prev.includes(op) ? prev.filter((o) => o !== op) : [...prev, op],
+    );
+
+  const { mutate, isPending } = useMutation({
+    mutationFn: (asDryRun: boolean) => {
+      const fd = new FormData();
+      if (files.negociacao) fd.append("negociacao", files.negociacao);
+      if (files.posicao) fd.append("posicao", files.posicao);
+      if (files.movimentacao) fd.append("movimentacao", files.movimentacao);
+      selectedOps.forEach((op) => fd.append("operations", op));
+      fd.append("dry_run", String(asDryRun));
+      fd.append("create_missing_assets", String(createMissingAssets));
+      if (workbookDt) fd.append("workbook_dt", workbookDt.toISOString());
+      return importB3(fd);
+    },
+    onSuccess: (data, asDryRun) => {
+      setReport(data);
+      if (asDryRun) {
+        setPreviewedSignature(currentSignature);
+        enqueueSnackbar("Pré-visualização gerada", { variant: "success" });
+      } else {
+        setPreviewedSignature(null);
+        enqueueSnackbar("Importação aplicada", { variant: "success" });
+      }
+    },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    onError: (error: any) => {
+      const data = error?.response?.data;
+      const message =
+        data?.operation && data?.detail
+          ? `${data.operation}: ${data.detail}`
+          : "Erro ao importar arquivos da B3";
+      enqueueSnackbar(message, { variant: "error" });
+    },
+  });
+
+  const canPreview =
+    selectedOps.length > 0 && (!needsWorkbookDt || workbookDt !== null);
+  const canApply = !dryRun && canPreview && previewedSignature === currentSignature;
+  const submitDisabled = isPending || (dryRun ? !canPreview : !canApply);
+
+  return (
+    <Drawer
+      open={open}
+      onClose={onClose}
+      anchor="right"
+      slotProps={{
+        transition: { onExited: resetState },
+        paper: {
+          sx: {
+            width: 650,
+            maxWidth: "100vw",
+            backgroundColor: getColor(Colors.neutral600),
+            boxShadow: "none",
+            backgroundImage: "none",
+          },
+        },
+      }}
+    >
+      <Stack spacing={3} sx={{ p: 3 }}>
+        <Typography variant="h6">Importar arquivos da B3</Typography>
+
+        <Stack spacing={1.5}>
+          <FileDropArea onFiles={handleFiles} />
+          {SLOT_LABELS.map(({ slot, label }) => {
+            const file = files[slot];
+            return file ? (
+              <Stack key={slot} direction="row" spacing={1} alignItems="center">
+                <Typography variant="caption" sx={{ minWidth: 96 }}>
+                  {label}
+                </Typography>
+                <Typography variant="body2" noWrap sx={{ flex: 1 }}>
+                  {file.name}
+                </Typography>
+                <IconButton
+                  size="small"
+                  onClick={() => clearSlot(slot)}
+                  aria-label={`Remover ${label}`}
+                >
+                  <CloseIcon fontSize="small" />
+                </IconButton>
+              </Stack>
+            ) : null;
+          })}
+          {unrecognized.length > 0 && (
+            <Typography variant="caption" color={getColor(Colors.danger200)}>
+              Não reconhecido: {unrecognized.join(", ")}. Esperado
+              negociacao-*.xlsx, posicao-*.xlsx, movimentacao-*.xlsx
+            </Typography>
+          )}
+        </Stack>
+
+        <Divider />
+
+        <Stack
+          spacing={2}
+          direction="row"
+          alignItems="center"
+          flexWrap="wrap"
+          useFlexGap
+        >
+          <Typography variant="subtitle2">Importações</Typography>
+          {OPERATIONS.map(({ op, label }) => {
+            const enabled = isOperationEnabled(op, files);
+            return (
+              <FormControlLabel
+                key={op}
+                control={
+                  <Checkbox
+                    checked={selectedOps.includes(op)}
+                    disabled={!enabled}
+                    onChange={() => toggleOp(op)}
+                  />
+                }
+                label={label}
+              />
+            );
+          })}
+        </Stack>
+
+        {needsWorkbookDt && (
+          <LocalizationProvider
+            dateAdapter={AdapterDateFns}
+            adapterLocale={ptBR}
+          >
+            <DateTimePicker
+              label="Data da posição"
+              value={workbookDt}
+              onChange={(value) => setWorkbookDt(value)}
+              format="dd/MM/yyyy HH:mm:ss"
+              slotProps={{ textField: { variant: "standard", required: true } }}
+            />
+          </LocalizationProvider>
+        )}
+
+        <Stack
+          direction="row"
+          spacing={4}
+          alignItems="flex-start"
+          flexWrap="wrap"
+          useFlexGap
+        >
+          <FormControlLabel
+            control={
+              <Switch
+                checked={dryRun}
+                onChange={(e) => setDryRun(e.target.checked)}
+              />
+            }
+            label="Dry run (pré-visualizar)"
+          />
+          {selectedOps.includes("negociacoes") && (
+            <Stack>
+              <FormControlLabel
+                control={
+                  <Switch
+                    checked={createMissingAssets}
+                    disabled={files.posicao === null}
+                    onChange={(e) => setCreateMissingAssets(e.target.checked)}
+                  />
+                }
+                label="Criar ativos ausentes"
+              />
+              {files.posicao === null && (
+                <Typography variant="caption" color="text.secondary">
+                  Envie o arquivo de posição para habilitar
+                </Typography>
+              )}
+            </Stack>
+          )}
+        </Stack>
+
+        {!dryRun && previewedSignature !== currentSignature && (
+          <Typography variant="caption" color="warning.main">
+            Pré-visualize a configuração atual antes de aplicar.
+          </Typography>
+        )}
+
+        <Stack direction="row" spacing={2} justifyContent="flex-end">
+          <Button variant="brand-text" onClick={onClose}>
+            Fechar
+          </Button>
+          <Button
+            variant="brand"
+            disabled={submitDisabled}
+            onClick={() => mutate(dryRun)}
+          >
+            {isPending ? (
+              <CircularProgress color="inherit" size={24} />
+            ) : dryRun ? (
+              "Pré-visualizar"
+            ) : (
+              "Aplicar"
+            )}
+          </Button>
+        </Stack>
+
+        {report && <B3ImportReport response={report} />}
+      </Stack>
+    </Drawer>
+  );
+};
+
+export default B3ImportDrawer;

--- a/react/src/pages/private/Assets/ImportB3/logic.test.ts
+++ b/react/src/pages/private/Assets/ImportB3/logic.test.ts
@@ -1,0 +1,99 @@
+import {
+  classifyB3File,
+  computeSignature,
+  isCreateMissingEnabled,
+  isOperationEnabled,
+  parseWorkbookDtFromFilename,
+  priceDiffPct,
+  type B3Files,
+} from "./logic";
+
+const assertEqual = <T>(actual: T, expected: T, message: string) => {
+  if (actual !== expected) {
+    throw new Error(`${message}: expected ${expected}, got ${actual}`);
+  }
+};
+
+// A pure-logic stand-in for File (avoids depending on a global File impl).
+const fakeFile = (name: string): File =>
+  ({ name, size: name.length }) as unknown as File;
+
+const files = (neg = false, pos = false, mov = false): B3Files => ({
+  negociacao: neg ? fakeFile("negociacao.xlsx") : null,
+  posicao: pos ? fakeFile("posicao-2026-04-29-12-00-00.xlsx") : null,
+  movimentacao: mov ? fakeFile("movimentacao.xlsx") : null,
+});
+
+// negociacoes needs the negociacao file
+assertEqual(isOperationEnabled("negociacoes", files(true)), true, "neg enabled");
+assertEqual(isOperationEnabled("negociacoes", files(false)), false, "neg disabled");
+
+// renda_fixa / tesouro need BOTH posicao and movimentacao
+assertEqual(isOperationEnabled("renda_fixa", files(false, true, true)), true, "rf enabled");
+assertEqual(isOperationEnabled("renda_fixa", files(false, true, false)), false, "rf needs mov");
+assertEqual(isOperationEnabled("tesouro", files(false, false, true)), false, "tesouro needs pos");
+
+// price diff percentage
+assertEqual(priceDiffPct("100", "110"), 10, "diff +10%");
+assertEqual(priceDiffPct("100", "90"), -10, "diff -10%");
+assertEqual(priceDiffPct(null, "90"), null, "no baseline -> null");
+assertEqual(priceDiffPct("0", "90"), null, "zero baseline -> null");
+
+// file classification by B3 filename convention
+assertEqual(classifyB3File("negociacao-2026.xlsx"), "negociacao", "negociacao classified");
+assertEqual(
+  classifyB3File("posicao-2026-04-29-12-00-00.xlsx"),
+  "posicao",
+  "posicao classified",
+);
+assertEqual(classifyB3File("movimentacao-2026.xlsx"), "movimentacao", "movimentacao classified");
+assertEqual(classifyB3File("relatorio.xlsx"), null, "unknown -> null");
+
+// filename parsing
+const parsed = parseWorkbookDtFromFilename("posicao-2026-04-29-12-00-00.xlsx");
+assertEqual(parsed?.getFullYear(), 2026, "year parsed");
+assertEqual(parsed?.getMonth(), 3, "month parsed (0-based April)");
+assertEqual(parsed?.getDate(), 29, "day parsed");
+assertEqual(parseWorkbookDtFromFilename("renamed.xlsx"), null, "bad name -> null");
+
+// create-missing gate: needs negociacoes selected AND posicao present
+assertEqual(
+  isCreateMissingEnabled(files(true, true), ["negociacoes"]),
+  true,
+  "create-missing enabled with neg+posicao",
+);
+assertEqual(
+  isCreateMissingEnabled(files(true, false), ["negociacoes"]),
+  false,
+  "create-missing needs posicao",
+);
+assertEqual(
+  isCreateMissingEnabled(files(true, true), ["renda_fixa"]),
+  false,
+  "create-missing needs negociacoes selected",
+);
+
+// signature changes when inputs change
+const base = files(false, true, true);
+const dt = new Date("2026-04-29T12:00:00");
+assertEqual(
+  computeSignature(base, ["renda_fixa"], dt, false) ===
+    computeSignature(base, ["renda_fixa"], dt, false),
+  true,
+  "stable signature for same inputs",
+);
+assertEqual(
+  computeSignature(base, ["renda_fixa"], dt, false) ===
+    computeSignature(base, ["renda_fixa", "tesouro"], dt, false),
+  false,
+  "ops change -> signature changes",
+);
+assertEqual(
+  computeSignature(base, ["renda_fixa"], dt, false) ===
+    computeSignature(base, ["renda_fixa"], dt, true),
+  false,
+  "create-missing toggle -> signature changes",
+);
+
+// eslint-disable-next-line no-console
+console.log("logic.test.ts passed");

--- a/react/src/pages/private/Assets/ImportB3/logic.ts
+++ b/react/src/pages/private/Assets/ImportB3/logic.ts
@@ -1,0 +1,79 @@
+import type { B3Operation } from "./types";
+
+export type B3Files = {
+  negociacao: File | null;
+  posicao: File | null;
+  movimentacao: File | null;
+};
+
+export type B3FileSlot = keyof B3Files;
+
+// B3 exports keep their original names (negociacao-*.xlsx, posicao-*.xlsx,
+// movimentacao-*.xlsx), so a single drop can be routed to the right slot.
+export const classifyB3File = (name: string): B3FileSlot | null => {
+  const lower = name.toLowerCase();
+  if (lower.startsWith("negociacao")) return "negociacao";
+  if (lower.startsWith("posicao")) return "posicao";
+  if (lower.startsWith("movimentacao")) return "movimentacao";
+  return null;
+};
+
+export const isOperationEnabled = (op: B3Operation, files: B3Files): boolean => {
+  if (op === "negociacoes") return files.negociacao !== null;
+  // renda_fixa and tesouro both require posicao AND movimentacao
+  return files.posicao !== null && files.movimentacao !== null;
+};
+
+// "Criar ativos ausentes" only matters for Negociações, and creating an asset
+// needs the Posição file as its source.
+export const isCreateMissingEnabled = (
+  files: B3Files,
+  operations: B3Operation[],
+): boolean => operations.includes("negociacoes") && files.posicao !== null;
+
+const FILENAME_RE = /posicao-(\d{4})-(\d{2})-(\d{2})-(\d{2})-(\d{2})-(\d{2})\.xlsx$/i;
+
+export const parseWorkbookDtFromFilename = (name: string): Date | null => {
+  const match = FILENAME_RE.exec(name);
+  if (!match) return null;
+  const [, y, mo, d, h, mi, s] = match;
+  return new Date(
+    Number(y),
+    Number(mo) - 1,
+    Number(d),
+    Number(h),
+    Number(mi),
+    Number(s),
+  );
+};
+
+// Percent change previous -> new; null when there's no usable baseline.
+export const priceDiffPct = (
+  previous: string | null | undefined,
+  next: string | null | undefined,
+): number | null => {
+  const prev = Number(previous);
+  const cur = Number(next);
+  if (!previous || !Number.isFinite(prev) || prev === 0 || !Number.isFinite(cur)) {
+    return null;
+  }
+  return ((cur - prev) / prev) * 100;
+};
+
+const fileKey = (file: File | null): string =>
+  file ? `${file.name}:${file.size}` : "-";
+
+export const computeSignature = (
+  files: B3Files,
+  operations: B3Operation[],
+  workbookDt: Date | null,
+  createMissingAssets: boolean,
+): string =>
+  JSON.stringify({
+    neg: fileKey(files.negociacao),
+    pos: fileKey(files.posicao),
+    mov: fileKey(files.movimentacao),
+    ops: [...operations].sort(),
+    dt: workbookDt ? workbookDt.toISOString() : "-",
+    cma: createMissingAssets,
+  });

--- a/react/src/pages/private/Assets/ImportB3/types.ts
+++ b/react/src/pages/private/Assets/ImportB3/types.ts
@@ -1,0 +1,34 @@
+export type B3Operation = "negociacoes" | "renda_fixa" | "tesouro";
+
+export type B3Transaction = {
+  action: string;
+  price: string;
+  quantity: string;
+  operation_date: string;
+};
+
+export type B3ActionEntry = {
+  code?: string | null;
+  action: string;
+  reason?: string;
+  description?: string;
+  asset_pk?: number;
+  type?: string;
+  new_price?: string;
+  previous_price?: string | null;
+  transactions?: B3Transaction[];
+  transaction?: B3Transaction;
+};
+
+export type B3OperationReport = {
+  dry_run: boolean;
+  actions: B3ActionEntry[];
+  workbook_dt?: string;
+  posicao_path?: string | null;
+  negociacao_path?: string | null;
+};
+
+export type B3ImportResponse = {
+  dry_run: boolean;
+  reports: Partial<Record<B3Operation, B3OperationReport>>;
+};

--- a/react/src/pages/private/Assets/Table/TopToolbar/index.tsx
+++ b/react/src/pages/private/Assets/Table/TopToolbar/index.tsx
@@ -15,6 +15,7 @@ import AddIcon from "@mui/icons-material/Add";
 import FilterListIcon from "@mui/icons-material/FilterList";
 import MoreVertIcon from "@mui/icons-material/MoreVert";
 import SearchIcon from "@mui/icons-material/Search";
+import UploadFileIcon from "@mui/icons-material/UploadFile";
 
 import {
   type MRT_PaginationState as PaginationState,
@@ -39,6 +40,7 @@ import { assetsFilterConfig } from "../../filterConfig";
 import NewTransactionDrawer from "../../../Transactions/components/NewTransactionDrawer";
 import CreateOrEditIncomeDrawer from "../../../Incomes/components/CreateOrEditIncomeDrawer";
 import { SearchBar } from "../../../components";
+import B3ImportDrawer from "../../ImportB3";
 
 const TopToolBarExtraActionsMenu = ({ table }: { table: DataTable<Row> }) => {
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
@@ -95,6 +97,7 @@ const TopToolBar = ({
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
   const [openTransactionDrawer, setOpenTransactionDrawer] = useState(false);
   const [openIncomeDrawer, setOpenIncomeDrawer] = useState(false);
+  const [openB3ImportDrawer, setOpenB3ImportDrawer] = useState(false);
 
   return (
     <>
@@ -134,6 +137,14 @@ const TopToolBar = ({
             </Button>
             <Button
               variant="neutral"
+              startIcon={<UploadFileIcon />}
+              size="large"
+              onClick={() => setOpenB3ImportDrawer(true)}
+            >
+              Importar B3
+            </Button>
+            <Button
+              variant="neutral"
               startIcon={<FilterListIcon />}
               onClick={(e) => setAnchorEl(e.currentTarget)}
             >
@@ -165,6 +176,10 @@ const TopToolBar = ({
         open={openIncomeDrawer}
         onClose={() => setOpenIncomeDrawer(false)}
         variant="asset"
+      />
+      <B3ImportDrawer
+        open={openB3ImportDrawer}
+        onClose={() => setOpenB3ImportDrawer(false)}
       />
     </>
   );

--- a/react/src/pages/private/Assets/api/index.ts
+++ b/react/src/pages/private/Assets/api/index.ts
@@ -3,6 +3,7 @@ import qs from "qs";
 import { apiProvider } from "../../../../api/methods";
 import { ApiListResponse, RawDateString } from "../../../../types";
 import { AssetCurrencies } from "../consts";
+import type { B3ImportResponse } from "../ImportB3/types";
 import { GroupBy, Kinds } from "../Reports/types";
 import {
   Asset,
@@ -14,6 +15,12 @@ import {
 } from "./models";
 
 const RESOURCE = "assets";
+
+// Pass FormData directly; axios derives the multipart boundary itself.
+export const importB3 = async (
+  formData: FormData,
+): Promise<B3ImportResponse> =>
+  (await apiProvider.post(`${RESOURCE}/b3_import`, formData)).data;
 
 type AssetsIndicatorsResponse = {
   ROI: number;


### PR DESCRIPTION
## What

Import B3 spreadsheet exports (negociações, posição, movimentação) from the Assets page — preview (dry run) then apply.

### Backend — `POST /api/v1/assets/b3_import`
- `@action` on `AssetViewSet` (multipart, JWT + investments-module/subscription permissions). Runs the existing B3 handlers and returns a combined, per-operation report.
- `B3ImportSerializer`: `.xlsx` (FileExtensionValidator) + 10MB cap, per-op file requirements, `workbook_dt` required for RF/Tesouro, `create_missing_assets` requires posição.
- `run_b3_import` orchestrator: reads uploads **in memory** (no temp files), dispatches selected handlers. Dry-run = all-or-nothing preview; apply = one transaction. Parse/format errors → clean `400 {operation, detail}`.
- Handler changes: export `import_b3_renda_fixa_positions`; optional `workbook_dt`; parsers accept `bytes` via a shared `open_workbook`; **trades applied chronologically** (B3 is most-recent-first); an over-sell is **skipped + reported**, not fatal; tesouro `current_price` quantized to 10 dp; PT skip/error reasons; asset description in report rows.
- Declare **openpyxl** as a project dependency (previously only present in the local venv → broke the container at boot).

### Frontend — Import drawer
- "Importar B3" toolbar button → drawer with a **single drop area** that auto-routes files by B3 filename; unrecognized names flagged.
- Op checkboxes auto-check as files load; **Dry run** / **Criar ativos ausentes** switches; posição datetime autofilled from filename; apply gated behind a clean preview.
- Grouped per-operation report with outlined design-system chips, PT labels, **price-update % diff** (green/red), asset description under the code, and a per-op **expand-to-full-drawer** view. State resets on close.

## Tests
- Backend: 65 b3 tests pass (`integrations/b3/tests`, `tests/integrations/test__b3_handlers.py`, `tests/integrations/test__b3_import_api.py`). Covers serializer validation, dry-run vs apply, all-or-nothing, chronological ordering, over-sell reporting, `workbook_dt` threading, price quantization.
- Frontend: `tsc --noEmit` clean; pure logic covered by `ImportB3/logic.test.ts` (gating, signature, filename classify/parse, price diff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)