### PR TITLE
Import B3 "Proventos Recebidos" (incomes) + UI

### DIFF
--- a/django/variable_income_assets/integrations/b3/__init__.py
+++ b/django/variable_income_assets/integrations/b3/__init__.py
@@ -1,6 +1,7 @@
 from .handlers import (
     import_b3_fixed_income_positions,
     import_b3_negociacoes,
+    import_b3_proventos,
     import_b3_renda_fixa_positions,
     import_b3_tesouro_positions,
 )
@@ -8,6 +9,7 @@ from .handlers import (
 __all__ = [
     "import_b3_negociacoes",
     "import_b3_fixed_income_positions",
+    "import_b3_proventos",
     "import_b3_renda_fixa_positions",
     "import_b3_tesouro_positions",
 ]

--- a/django/variable_income_assets/integrations/b3/handlers.py
+++ b/django/variable_income_assets/integrations/b3/handlers.py
@@ -12,9 +12,20 @@ from django.utils import timezone
 
 from rest_framework.exceptions import ValidationError as DRFValidationError
 
-from ...choices import AssetObjectives, AssetTypes, Currencies, LiquidityTypes
-from ...models import Asset, AssetMetaData, Transaction
+from ...adapters.key_value_store import get_dollar_conversion_rate
+from ...choices import (
+    AssetObjectives,
+    AssetTypes,
+    Currencies,
+    LiquidityTypes,
+    PassiveIncomeEventTypes,
+    PassiveIncomeTypes,
+)
+from ...domain import events
+from ...models import Asset, AssetMetaData, PassiveIncome, Transaction
 from ...serializers import AssetSerializer, TransactionListSerializer
+from ...service_layer import messagebus
+from ...service_layer.unit_of_work import DjangoUnitOfWork
 from ._workbook import WorkbookSource
 from .movimentacao import parse_movements
 from .negociacao import (
@@ -24,10 +35,12 @@ from .negociacao import (
     resolve_negociacao_path,
 )
 from .parser import parse_positions
+from .proventos import parse_proventos, resolve_proventos_path
 from .schemas import (
     B3FixedIncomeAction,
     B3FixedIncomeMovement,
     B3FixedIncomePosition,
+    B3ProventoType,
     B3StockNegotiation,
     B3StockPosition,
     B3TesouroMovement,
@@ -787,6 +800,139 @@ def import_b3_fixed_income_positions(
     )
 
 
+_PROVENTO_TYPE_MAP = {
+    B3ProventoType.DIVIDENDO: PassiveIncomeTypes.dividend,
+    B3ProventoType.JSCP: PassiveIncomeTypes.jcp,
+    B3ProventoType.RENDIMENTO: PassiveIncomeTypes.income,
+    B3ProventoType.REEMBOLSO: PassiveIncomeTypes.reimbursement,
+}
+
+
+def _proventos_actions(*, user_id: int, proventos_path_resolved) -> list[dict]:
+    proventos = parse_proventos(proventos_path_resolved)
+    if not proventos:
+        return []
+
+    # Bulk-load every involved asset and their existing credited incomes (2 queries
+    # total) instead of querying per row; persist with a single bulk_create.
+    assets_by_code = {
+        asset.code: asset
+        for asset in Asset.objects.filter(
+            user_id=user_id, code__in={p.code for p in proventos}
+        )
+    }
+    existing = set(
+        PassiveIncome.objects.filter(
+            asset_id__in=[a.id for a in assets_by_code.values()],
+            event_type=PassiveIncomeEventTypes.credited,
+        ).values_list("asset_id", "type", "operation_date", "amount")
+    )
+
+    today = timezone.localdate()
+    actions: list[dict] = []
+    to_create: list[PassiveIncome] = []
+
+    for provento in proventos:
+        asset = assets_by_code.get(provento.code)
+        if asset is None:
+            actions.append(
+                {"code": provento.code, "action": "skipped", "reason": "ativo não cadastrado"}
+            )
+            continue
+
+        income_type = _PROVENTO_TYPE_MAP[provento.kind]
+        base = {
+            "code": provento.code,
+            "description": asset.description,
+            "income": {
+                "type": income_type,
+                "amount": str(provento.amount),
+                "currency": asset.currency,
+                "operation_date": provento.payment_date.isoformat(),
+            },
+        }
+
+        key = (asset.id, income_type, provento.payment_date, provento.amount)
+        if key in existing:
+            actions.append({**base, "action": "skipped", "reason": "provento já cadastrado"})
+            continue
+        if provento.payment_date > today:
+            actions.append(
+                {
+                    **base,
+                    "action": "error",
+                    "reason": "rendimento creditado não pode estar no futuro",
+                }
+            )
+            continue
+        choice = AssetTypes.get_choice(asset.type)
+        if not choice.accept_incomes:
+            actions.append(
+                {
+                    **base,
+                    "action": "error",
+                    "reason": f"ativos de classe {choice.label} não aceitam rendimentos",
+                }
+            )
+            continue
+
+        to_create.append(
+            PassiveIncome(
+                asset=asset,
+                type=income_type,
+                event_type=PassiveIncomeEventTypes.credited,
+                amount=provento.amount,
+                operation_date=provento.payment_date,
+                current_currency_conversion_rate=(
+                    Decimal("1")
+                    if asset.currency == Currencies.real
+                    else get_dollar_conversion_rate()
+                ),
+            )
+        )
+        existing.add(key)  # also dedupe duplicate rows within the same file
+        actions.append({**base, "action": "income_created", "asset_pk": asset.id})
+
+    if to_create:
+        PassiveIncome.objects.bulk_create(to_create)
+        # bulk_create skips the messagebus, so upsert each affected asset's read
+        # model once (PassiveIncomeCreated -> upsert_read_model, aggregate fields).
+        for affected_asset_id in {income.asset_id for income in to_create}:
+            with DjangoUnitOfWork(asset_pk=affected_asset_id) as uow:
+                messagebus.handle(
+                    message=events.PassiveIncomeCreated(asset_pk=affected_asset_id),
+                    uow=uow,
+                )
+
+    return actions
+
+
+def import_b3_proventos(
+    *,
+    user_id: int,
+    dry_run: bool = True,
+    proventos_path: str | None = None,
+) -> dict:
+    proventos_resolved = resolve_proventos_path(proventos_path)
+
+    actions: list[dict] = []
+    try:
+        with djtransaction.atomic():
+            actions = _proventos_actions(
+                user_id=user_id, proventos_path_resolved=proventos_resolved
+            )
+            if dry_run:
+                raise _DryRunRollback
+    except _DryRunRollback:
+        pass
+
+    return {
+        "dry_run": dry_run,
+        "proventos_path": _source_label(proventos_resolved),
+        "actions": actions,
+    }
+
+
 def format_report(report: dict) -> str:
     lines: list[str] = []
     label = "DRY RUN" if report["dry_run"] else "APPLIED"
@@ -797,6 +943,8 @@ def format_report(report: dict) -> str:
         lines.append(f"  posicao:  {report['posicao_path']}")
     if "negociacao_path" in report:
         lines.append(f"  negociacao: {report['negociacao_path']}")
+    if "proventos_path" in report:
+        lines.append(f"  proventos: {report['proventos_path']}")
     lines.append("")
 
     counts: dict[str, int] = defaultdict(int)
@@ -839,6 +987,11 @@ def _format_action_detail(entry: dict) -> str:
     if action == "transaction_created":
         tx = entry["transaction"]
         return f"{tx['action']} {tx['quantity']} @ {tx['price']} on {tx['operation_date']}"
+    if action == "income_created":
+        inc = entry["income"]
+        return f"{inc['type']} {inc['amount']} on {inc['operation_date']}"
+    if action == "error":
+        return entry.get("reason", "")
     if action == "exists":
         return f"already in DB ({entry.get('type', '')})"
     if action == "asset_created":

--- a/django/variable_income_assets/integrations/b3/handlers.py
+++ b/django/variable_income_assets/integrations/b3/handlers.py
@@ -114,11 +114,38 @@ def _build_description(position: B3FixedIncomePosition) -> str:
     return f"{base} - venc {position.maturity_date.strftime('%d/%m/%Y')}"
 
 
+def _bulk_fetch_fixed_br_metadata(codes) -> dict[str, AssetMetaData]:
+    # The global (B3-synced) metadata row per code, scoped by type+currency and
+    # asset__isnull so we never touch a same-code row of another type/currency or
+    # a user's direct self-custody metadata (AssetMetaData.code is not unique).
+    return {
+        metadata.code: metadata
+        for metadata in AssetMetaData.objects.filter(
+            code__in=set(codes),
+            type=AssetTypes.fixed_br,
+            currency=Currencies.real,
+            asset__isnull=True,
+        )
+    }
+
+
+def _bulk_fetch_existing_transactions(asset_ids) -> dict[int, set]:
+    # {asset_id: {(action, operation_date, quantity, price)}} for transaction dedup.
+    existing: dict[int, set] = defaultdict(set)
+    for asset_id, action, operation_date, quantity, price in Transaction.objects.filter(
+        asset_id__in=asset_ids
+    ).values_list("asset_id", "action", "operation_date", "quantity", "price"):
+        existing[asset_id].add((action, operation_date, quantity, price))
+    return existing
+
+
 def _update_existing_price(
     *,
     code: str,
     new_price: Decimal | None,
     workbook_dt: datetime,
+    metadata: AssetMetaData | None,
+    updates: list[AssetMetaData],
     description: str | None = None,
 ) -> dict:
     if new_price is None:
@@ -129,17 +156,6 @@ def _update_existing_price(
             "reason": "sem preço atual na posição",
         }
 
-    # B3 fixed income/Tesouro is BRL and lives in the global (B3-synced) metadata
-    # row. Scope by type+currency and asset__isnull so we never touch a same-code
-    # row of another type/currency or a user's direct self-custody metadata
-    # (AssetMetaData.code is not globally unique).
-    metadata_qs = AssetMetaData.objects.filter(
-        code=code,
-        type=AssetTypes.fixed_br,
-        currency=Currencies.real,
-        asset__isnull=True,
-    )
-    metadata = metadata_qs.first()
     if metadata is None:
         return {
             "code": code,
@@ -159,12 +175,15 @@ def _update_existing_price(
             "workbook_dt": workbook_dt.isoformat(),
         }
 
-    metadata_qs.update(current_price=new_price, current_price_updated_at=timezone.now())
+    previous_price = metadata.current_price
+    metadata.current_price = new_price
+    metadata.current_price_updated_at = timezone.now()
+    updates.append(metadata)
     return {
         "code": code,
         "description": description,
         "action": "price_updated",
-        "previous_price": str(metadata.current_price) if metadata.current_price else None,
+        "previous_price": str(previous_price) if previous_price else None,
         "new_price": str(new_price),
     }
 
@@ -328,6 +347,17 @@ def _renda_fixa_actions(
     for movement in movements:
         movements_by_code[movement.code].append(movement)
 
+    # Bulk-load which codes already exist + their metadata (2 queries) instead of
+    # one lookup per position; price writes are batched via bulk_update at the end.
+    position_codes = {p.code for p in positions if p.code}
+    existing_codes = set(
+        Asset.objects.filter(
+            user_id=user_id, type=AssetTypes.fixed_br, code__in=position_codes
+        ).values_list("code", flat=True)
+    )
+    metadata_by_code = _bulk_fetch_fixed_br_metadata(existing_codes)
+    price_updates: list[AssetMetaData] = []
+
     actions: list[dict] = []
     for position in positions:
         if not position.code:
@@ -341,14 +371,14 @@ def _renda_fixa_actions(
             )
             continue
 
-        if Asset.objects.filter(
-            user_id=user_id, code=position.code, type=AssetTypes.fixed_br
-        ).exists():
+        if position.code in existing_codes:
             actions.append(
                 _update_existing_price(
                     code=position.code,
                     new_price=position.current_price,
                     workbook_dt=workbook_dt,
+                    metadata=metadata_by_code.get(position.code),
+                    updates=price_updates,
                     description=_build_description(position),
                 )
             )
@@ -386,17 +416,16 @@ def _renda_fixa_actions(
             )
         )
 
+    if price_updates:
+        AssetMetaData.objects.bulk_update(
+            price_updates, ["current_price", "current_price_updated_at"]
+        )
     return actions
 
 
 def _create_missing_transactions(
-    *, user, asset, movements: list[B3TesouroMovement]
+    *, user, asset, movements: list[B3TesouroMovement], existing: set
 ) -> list[dict]:
-    existing = set(
-        Transaction.objects.filter(asset=asset).values_list(
-            "action", "operation_date", "quantity", "price"
-        )
-    )
     context = {"request": _RequestContext(user)}
     created: list[dict] = []
     for movement in sorted(movements, key=lambda m: m.operation_date):
@@ -449,17 +478,33 @@ def _tesouro_actions(
     for td_movement in td_movements:
         td_by_name[td_movement.name].append(td_movement)
 
+    # Bulk-load existing assets, their metadata, and their transactions (for dedup)
+    # up front; batch the price writes via bulk_update at the end.
+    existing_assets_by_isin = {
+        asset.code: asset
+        for asset in Asset.objects.filter(
+            user_id=user_id,
+            type=AssetTypes.fixed_br,
+            code__in={p.isin for p in td_positions},
+        )
+    }
+    metadata_by_code = _bulk_fetch_fixed_br_metadata(existing_assets_by_isin)
+    existing_tx_by_asset = _bulk_fetch_existing_transactions(
+        [asset.id for asset in existing_assets_by_isin.values()]
+    )
+    price_updates: list[AssetMetaData] = []
+
     actions: list[dict] = []
     for td_position in td_positions:
-        existing_asset = Asset.objects.filter(
-            user_id=user_id, code=td_position.isin, type=AssetTypes.fixed_br
-        ).first()
+        existing_asset = existing_assets_by_isin.get(td_position.isin)
         if existing_asset is not None:
             actions.append(
                 _update_existing_price(
                     code=td_position.isin,
                     new_price=td_position.current_price,
                     workbook_dt=workbook_dt,
+                    metadata=metadata_by_code.get(td_position.isin),
+                    updates=price_updates,
                     description=_build_tesouro_description(td_position),
                 )
             )
@@ -468,6 +513,7 @@ def _tesouro_actions(
                     user=user,
                     asset=existing_asset,
                     movements=td_by_name.get(td_position.name, []),
+                    existing=existing_tx_by_asset[existing_asset.id],
                 )
             )
             continue
@@ -490,6 +536,10 @@ def _tesouro_actions(
             )
         )
 
+    if price_updates:
+        AssetMetaData.objects.bulk_update(
+            price_updates, ["current_price", "current_price_updated_at"]
+        )
     return actions
 
 
@@ -587,10 +637,21 @@ def _negociacao_actions(
         ):
             position_by_code[position.code] = position
 
+    # Bulk-load the existing assets (by code) and their transactions (for dedup)
+    # up front instead of one query per code.
+    assets_by_code: dict[str, Asset] = {}
+    for asset in Asset.objects.filter(
+        user_id=user_id, code__in=set(by_code)
+    ).order_by("id"):
+        assets_by_code.setdefault(asset.code, asset)
+    existing_tx_by_asset = _bulk_fetch_existing_transactions(
+        [asset.id for asset in assets_by_code.values()]
+    )
+
     actions: list[dict] = []
 
     for code, code_negotiations in by_code.items():
-        asset = Asset.objects.filter(user_id=user_id, code=code).first()
+        asset = assets_by_code.get(code)
         asset_action: dict | None = None
 
         if asset is None:
@@ -622,11 +683,7 @@ def _negociacao_actions(
         else:
             asset_pk = asset.id
             description = asset.description
-            existing = set(
-                Transaction.objects.filter(asset=asset).values_list(
-                    "action", "operation_date", "quantity", "price"
-                )
-            )
+            existing = existing_tx_by_asset[asset.id]
 
         # Apply chronologically: B3 reports list trades most-recent-first, but the
         # domain enforces a running balance (no selling more than held).

--- a/django/variable_income_assets/integrations/b3/handlers.py
+++ b/django/variable_income_assets/integrations/b3/handlers.py
@@ -911,7 +911,9 @@ def _proventos_actions(*, user_id: int, proventos_path_resolved) -> list[dict]:
 
         key = (asset.id, income_type, provento.payment_date, provento.amount)
         if key in existing:
-            actions.append({**base, "action": "skipped", "reason": "provento já cadastrado"})
+            actions.append(
+                {**base, "action": "already_exists", "reason": "provento já cadastrado"}
+            )
             continue
         if provento.payment_date > today:
             actions.append(
@@ -1032,7 +1034,7 @@ def _format_action_detail(entry: dict) -> str:
         return f"{entry.get('previous_price', '—')} -> {entry['new_price']}"
     if action == "price_skipped":
         return f"metadata @ {entry['metadata_updated_at']} >= workbook"
-    if action == "skipped":
+    if action in ("skipped", "already_exists"):
         return entry.get("reason", "")
     if action == "created":
         head = f"asset #{entry['asset_pk']}  {entry['description']}"

--- a/django/variable_income_assets/integrations/b3/handlers.py
+++ b/django/variable_income_assets/integrations/b3/handlers.py
@@ -866,9 +866,21 @@ _PROVENTO_TYPE_MAP = {
 
 
 def _proventos_actions(*, user_id: int, proventos_path_resolved) -> list[dict]:
-    proventos = parse_proventos(proventos_path_resolved)
+    proventos, skipped = parse_proventos(proventos_path_resolved)
+
+    # Rows whose event type we don't map (e.g. fixed-income "PAGAMENTO DE JUROS").
+    # Reported as "unsupported_event" (not "skipped") so the report's "ignored"
+    # filter never hides them — the user should always see what we couldn't import.
+    skipped_actions = [
+        {
+            "code": s.code,
+            "action": "unsupported_event",
+            "reason": f"tipo de evento não suportado: {s.label}",
+        }
+        for s in skipped
+    ]
     if not proventos:
-        return []
+        return skipped_actions
 
     # Bulk-load every involved asset and their existing credited incomes (2 queries
     # total) instead of querying per row; persist with a single bulk_create.
@@ -886,7 +898,7 @@ def _proventos_actions(*, user_id: int, proventos_path_resolved) -> list[dict]:
     )
 
     today = timezone.localdate()
-    actions: list[dict] = []
+    actions: list[dict] = list(skipped_actions)
     to_create: list[PassiveIncome] = []
 
     for provento in proventos:
@@ -1034,7 +1046,7 @@ def _format_action_detail(entry: dict) -> str:
         return f"{entry.get('previous_price', '—')} -> {entry['new_price']}"
     if action == "price_skipped":
         return f"metadata @ {entry['metadata_updated_at']} >= workbook"
-    if action in ("skipped", "already_exists"):
+    if action in ("skipped", "already_exists", "unsupported_event"):
         return entry.get("reason", "")
     if action == "created":
         head = f"asset #{entry['asset_pk']}  {entry['description']}"

--- a/django/variable_income_assets/integrations/b3/import_service.py
+++ b/django/variable_income_assets/integrations/b3/import_service.py
@@ -24,6 +24,10 @@ from .parser import B3ParserError
 _OPERATION_ERRORS = (B3ParserError, B3ImportError, zipfile.BadZipFile, InvalidFileException)
 
 
+class _DryRunBatchRollback(Exception):
+    """Internal: unwinds the shared transaction after a dry-run preview."""
+
+
 class B3ImportOperationError(Exception):
     """A single B3 operation failed while parsing/running its files."""
 
@@ -114,14 +118,22 @@ def run_b3_import(
         "proventos": _read(proventos_file),
     }
 
-    def run_all() -> dict:
-        reports: dict = {}
-        for operation in operations:
+    # proventos must run after the asset-creating ops so it can match assets created
+    # in the same import (e.g. an FII created from negociações, then its dividends).
+    ordered_ops = sorted(operations, key=lambda op: op == "proventos")
+
+    reports: dict = {}
+
+    def run_all() -> None:
+        for operation in ordered_ops:
             try:
-                reports[operation] = _run_operation(
+                # Always persist within the shared transaction so each op sees what
+                # the previous ones created; the whole batch is rolled back below
+                # when this is a dry run.
+                report = _run_operation(
                     operation,
                     user_id=user_id,
-                    dry_run=dry_run,
+                    dry_run=False,
                     workbook_dt=workbook_dt,
                     create_missing_assets=create_missing_assets,
                     **files,
@@ -134,11 +146,17 @@ def run_b3_import(
                 raise B3ImportOperationError(
                     operation=operation, detail=_format_drf_error(exc)
                 ) from exc
-        return reports
+            report["dry_run"] = dry_run  # the report reflects the requested mode
+            reports[operation] = report
 
-    if dry_run:
-        # each handler self-rolls-back; the first op error aborts the whole preview
-        return {"dry_run": dry_run, "reports": run_all()}
+    # One transaction across every op: all-or-nothing on apply, and on a dry run we
+    # let the ops see each other's writes before rolling the whole thing back.
+    try:
+        with djtransaction.atomic():
+            run_all()
+            if dry_run:
+                raise _DryRunBatchRollback
+    except _DryRunBatchRollback:
+        pass
 
-    with djtransaction.atomic():  # all-or-nothing across ops on apply
-        return {"dry_run": dry_run, "reports": run_all()}
+    return {"dry_run": dry_run, "reports": reports}

--- a/django/variable_income_assets/integrations/b3/import_service.py
+++ b/django/variable_income_assets/integrations/b3/import_service.py
@@ -12,6 +12,7 @@ from rest_framework.exceptions import ValidationError as DRFValidationError
 from .handlers import (
     B3ImportError,
     import_b3_negociacoes,
+    import_b3_proventos,
     import_b3_renda_fixa_positions,
     import_b3_tesouro_positions,
 )
@@ -63,6 +64,7 @@ def _run_operation(
     negociacao: bytes | None,
     posicao: bytes | None,
     movimentacao: bytes | None,
+    proventos: bytes | None,
 ) -> dict:
     if operation == "negociacoes":
         return import_b3_negociacoes(
@@ -71,6 +73,10 @@ def _run_operation(
             create_missing_assets=create_missing_assets,
             negociacao_path=negociacao,
             posicao_path=posicao,
+        )
+    if operation == "proventos":
+        return import_b3_proventos(
+            user_id=user_id, dry_run=dry_run, proventos_path=proventos
         )
     if operation == "renda_fixa":
         return import_b3_renda_fixa_positions(
@@ -99,11 +105,13 @@ def run_b3_import(
     negociacao_file: UploadedFile | None,
     posicao_file: UploadedFile | None,
     movimentacao_file: UploadedFile | None,
+    proventos_file: UploadedFile | None = None,
 ) -> dict:
     files = {
         "negociacao": _read(negociacao_file),
         "posicao": _read(posicao_file),
         "movimentacao": _read(movimentacao_file),
+        "proventos": _read(proventos_file),
     }
 
     def run_all() -> dict:

--- a/django/variable_income_assets/integrations/b3/negociacao.py
+++ b/django/variable_income_assets/integrations/b3/negociacao.py
@@ -25,6 +25,15 @@ COMPRA_VENDA_LABELS = {
     "Venda": B3FixedIncomeAction.SELL,
 }
 
+
+def _normalize_negotiation_code(code: str) -> str:
+    # Fractional-market trades carry a trailing "F" (e.g. "UNIP6F"); the asset is
+    # the same as the round-lot ticker ("UNIP6"), so drop it. Only strip when the
+    # char before is a digit, since real tickers always end in a number.
+    if len(code) > 1 and code[-1] == "F" and code[-2].isdigit():
+        return code[:-1]
+    return code
+
 NEGOCIACAO_REQUIRED_HEADERS = (
     "Data do Negócio",
     "Tipo de Movimentação",
@@ -201,8 +210,10 @@ def parse_negotiations(path: WorkbookSource) -> list[B3StockNegotiation]:
 
             negotiations.append(
                 B3StockNegotiation(
-                    code=_to_required_str(
-                        code_raw, column="Código de Negociação", row_index=row_index
+                    code=_normalize_negotiation_code(
+                        _to_required_str(
+                            code_raw, column="Código de Negociação", row_index=row_index
+                        )
                     ),
                     action=action,
                     operation_date=_to_required_date(

--- a/django/variable_income_assets/integrations/b3/proventos.py
+++ b/django/variable_income_assets/integrations/b3/proventos.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 from ._workbook import WorkbookSource, open_workbook
 from .parser import PROJECT_ROOT, B3ParserError
-from .schemas import B3Provento, B3ProventoType
+from .schemas import B3Provento, B3ProventoSkip, B3ProventoType
 
 PROVENTOS_SHEET = "Proventos Recebidos"
 PROVENTOS_GLOB_PATTERN = "proventos-*.xlsx"
@@ -97,7 +97,9 @@ def _code_from_produto(produto: str) -> str:
     return produto.split(" - ", 1)[0].strip()
 
 
-def parse_proventos(path: WorkbookSource) -> list[B3Provento]:
+def parse_proventos(
+    path: WorkbookSource,
+) -> tuple[list[B3Provento], list[B3ProventoSkip]]:
     workbook = open_workbook(path)
     try:
         if PROVENTOS_SHEET not in workbook.sheetnames:
@@ -113,24 +115,27 @@ def parse_proventos(path: WorkbookSource) -> list[B3Provento]:
 
         h = _build_header_index(header_row, required=REQUIRED_HEADERS)
         proventos: list[B3Provento] = []
+        skipped: list[B3ProventoSkip] = []
 
         for row_index, row in enumerate(rows, start=2):
             produto = row[h["Produto"]] if h["Produto"] < len(row) else None
             if _is_blank(produto):
                 continue  # blank separator + the trailing "Total" row
 
+            code = _code_from_produto(
+                _to_required_str(produto, column="Produto", row_index=row_index)
+            )
             label = str(row[h["Tipo de Evento"]] or "").strip()
             kind = EVENT_LABELS.get(label)
             if kind is None:
-                raise B3ParserError(
-                    f"row {row_index}: unexpected Tipo de Evento {label!r}"
-                )
+                # Unmapped event type (e.g. fixed-income "PAGAMENTO DE JUROS"):
+                # skip the row and report it instead of aborting the import.
+                skipped.append(B3ProventoSkip(code=code, label=label))
+                continue
 
             proventos.append(
                 B3Provento(
-                    code=_code_from_produto(
-                        _to_required_str(produto, column="Produto", row_index=row_index)
-                    ),
+                    code=code,
                     kind=kind,
                     payment_date=_to_required_date(
                         row[h["Pagamento"]], column="Pagamento", row_index=row_index
@@ -141,6 +146,6 @@ def parse_proventos(path: WorkbookSource) -> list[B3Provento]:
                 )
             )
 
-        return proventos
+        return proventos, skipped
     finally:
         workbook.close()

--- a/django/variable_income_assets/integrations/b3/proventos.py
+++ b/django/variable_income_assets/integrations/b3/proventos.py
@@ -1,0 +1,146 @@
+from datetime import date, datetime
+from decimal import Decimal, InvalidOperation
+from pathlib import Path
+
+from ._workbook import WorkbookSource, open_workbook
+from .parser import PROJECT_ROOT, B3ParserError
+from .schemas import B3Provento, B3ProventoType
+
+PROVENTOS_SHEET = "Proventos Recebidos"
+PROVENTOS_GLOB_PATTERN = "proventos-*.xlsx"
+
+REQUIRED_HEADERS = (
+    "Produto",
+    "Pagamento",
+    "Tipo de Evento",
+    "Valor líquido",
+)
+
+# B3 "Tipo de Evento" -> normalized kind. Maps 1:1 to PassiveIncomeTypes downstream.
+EVENT_LABELS = {
+    "Dividendo": B3ProventoType.DIVIDENDO,
+    "Juros Sobre Capital Próprio": B3ProventoType.JSCP,
+    "Rendimento": B3ProventoType.RENDIMENTO,
+    "Reembolso": B3ProventoType.REEMBOLSO,
+}
+
+
+def resolve_proventos_path(source: WorkbookSource | None) -> WorkbookSource:
+    if isinstance(source, bytes):
+        return source
+    if source is not None:
+        return Path(source)
+    candidates = sorted(
+        PROJECT_ROOT.glob(PROVENTOS_GLOB_PATTERN),
+        key=lambda p: p.stat().st_mtime,
+        reverse=True,
+    )
+    if not candidates:
+        raise B3ParserError(f"no {PROVENTOS_GLOB_PATTERN} found in {PROJECT_ROOT}")
+    return candidates[0]
+
+
+def _is_blank(value) -> bool:
+    if value is None:
+        return True
+    return bool(isinstance(value, str) and value.strip() in ("", "-"))
+
+
+def _to_required_str(value, *, column: str, row_index: int) -> str:
+    if _is_blank(value):
+        raise B3ParserError(f"row {row_index}: required column {column!r} is blank")
+    return str(value).strip()
+
+
+def _to_required_date(value, *, column: str, row_index: int) -> date:
+    if _is_blank(value):
+        raise B3ParserError(f"row {row_index}: required column {column!r} is blank")
+    if isinstance(value, datetime):
+        return value.date()
+    if isinstance(value, date):
+        return value
+    try:
+        return datetime.strptime(str(value).strip(), "%d/%m/%Y").date()
+    except ValueError as exc:
+        raise B3ParserError(
+            f"row {row_index}: could not parse date in {column!r}: {value!r}"
+        ) from exc
+
+
+def _to_required_decimal(value, *, column: str, row_index: int) -> Decimal:
+    if _is_blank(value):
+        raise B3ParserError(f"row {row_index}: required column {column!r} is blank")
+    try:
+        return Decimal(str(value).strip())
+    except (InvalidOperation, ValueError) as exc:
+        raise B3ParserError(
+            f"row {row_index}: could not parse decimal in {column!r}: {value!r}"
+        ) from exc
+
+
+def _build_header_index(header_row: tuple, *, required: tuple[str, ...]) -> dict[str, int]:
+    index: dict[str, int] = {}
+    for i, cell in enumerate(header_row):
+        if cell is None:
+            continue
+        index[str(cell).strip()] = i
+
+    for header in required:
+        if header not in index:
+            raise B3ParserError(f"missing column: {header}")
+
+    return index
+
+
+def _code_from_produto(produto: str) -> str:
+    # "BBAS3 - BANCO DO BRASIL S/A" -> "BBAS3"
+    return produto.split(" - ", 1)[0].strip()
+
+
+def parse_proventos(path: WorkbookSource) -> list[B3Provento]:
+    workbook = open_workbook(path)
+    try:
+        if PROVENTOS_SHEET not in workbook.sheetnames:
+            raise B3ParserError(f"sheet {PROVENTOS_SHEET!r} not found")
+
+        sheet = workbook[PROVENTOS_SHEET]
+        rows = sheet.iter_rows(values_only=True)
+
+        try:
+            header_row = next(rows)
+        except StopIteration as exc:
+            raise B3ParserError(f"empty sheet {PROVENTOS_SHEET!r}") from exc
+
+        h = _build_header_index(header_row, required=REQUIRED_HEADERS)
+        proventos: list[B3Provento] = []
+
+        for row_index, row in enumerate(rows, start=2):
+            produto = row[h["Produto"]] if h["Produto"] < len(row) else None
+            if _is_blank(produto):
+                continue  # blank separator + the trailing "Total" row
+
+            label = str(row[h["Tipo de Evento"]] or "").strip()
+            kind = EVENT_LABELS.get(label)
+            if kind is None:
+                raise B3ParserError(
+                    f"row {row_index}: unexpected Tipo de Evento {label!r}"
+                )
+
+            proventos.append(
+                B3Provento(
+                    code=_code_from_produto(
+                        _to_required_str(produto, column="Produto", row_index=row_index)
+                    ),
+                    kind=kind,
+                    payment_date=_to_required_date(
+                        row[h["Pagamento"]], column="Pagamento", row_index=row_index
+                    ),
+                    amount=_to_required_decimal(
+                        row[h["Valor líquido"]], column="Valor líquido", row_index=row_index
+                    ),
+                )
+            )
+
+        return proventos
+    finally:
+        workbook.close()

--- a/django/variable_income_assets/integrations/b3/schemas.py
+++ b/django/variable_income_assets/integrations/b3/schemas.py
@@ -20,6 +20,22 @@ class B3FixedIncomeAction(StrEnum):
     SELL = "SELL"
 
 
+class B3ProventoType(StrEnum):
+    DIVIDENDO = "DIVIDENDO"
+    JSCP = "JSCP"
+    RENDIMENTO = "RENDIMENTO"
+    REEMBOLSO = "REEMBOLSO"
+
+
+class B3Provento(BaseModel):
+    code: str
+    kind: B3ProventoType
+    payment_date: date
+    amount: Decimal
+
+    model_config = ConfigDict(frozen=True)
+
+
 class B3FixedIncomePosition(BaseModel):
     kind: B3FixedIncomeKind
     description: str

--- a/django/variable_income_assets/integrations/b3/schemas.py
+++ b/django/variable_income_assets/integrations/b3/schemas.py
@@ -36,6 +36,15 @@ class B3Provento(BaseModel):
     model_config = ConfigDict(frozen=True)
 
 
+class B3ProventoSkip(BaseModel):
+    # A row whose "Tipo de Evento" we don't map (e.g. fixed-income "PAGAMENTO DE
+    # JUROS"); surfaced in the report instead of aborting the whole import.
+    code: str
+    label: str
+
+    model_config = ConfigDict(frozen=True)
+
+
 class B3FixedIncomePosition(BaseModel):
     kind: B3FixedIncomeKind
     description: str

--- a/django/variable_income_assets/integrations/b3/tests/test_b3_negociacao.py
+++ b/django/variable_income_assets/integrations/b3/tests/test_b3_negociacao.py
@@ -66,6 +66,28 @@ def test_happy_path(tmp_path):
     assert negotiations[2].code == "BTLG11"
 
 
+def test_strips_fractional_market_suffix(tmp_path):
+    # "UNIP6F" (fractional market) is the same asset as "UNIP6"
+    frac = [
+        "02/04/2026", "Compra", "Fracionário", "-", INSTITUICAO,
+        "UNIP6F", 7, 80.5, 563.5,
+    ]
+    path = _build(tmp_path, [frac])
+
+    negotiations = parse_negotiations(path)
+
+    assert negotiations[0].code == "UNIP6"
+
+
+def test_keeps_code_when_f_not_fractional_suffix(tmp_path):
+    # a real ticker never ends in a digit+"F"; leave non-matching codes untouched
+    path = _build(tmp_path, [BBAS3_BUY])
+
+    negotiations = parse_negotiations(path)
+
+    assert negotiations[0].code == "BBAS3"
+
+
 def test_skips_unknown_movement_label(tmp_path):
     weird = list(BBAS3_BUY)
     weird[1] = "Bonificação"

--- a/django/variable_income_assets/serializers.py
+++ b/django/variable_income_assets/serializers.py
@@ -654,7 +654,7 @@ class AssetOperationPeriodSerializer(serializers.Serializer):
     roi = serializers.DecimalField(max_digits=20, decimal_places=4, allow_null=True)
 
 
-B3_IMPORT_OPERATIONS = ("negociacoes", "renda_fixa", "tesouro")
+B3_IMPORT_OPERATIONS = ("negociacoes", "renda_fixa", "tesouro", "proventos")
 B3_MAX_UPLOAD_BYTES = 10 * 1024 * 1024  # 10 MB
 
 
@@ -680,6 +680,11 @@ class B3ImportSerializer(serializers.Serializer):
         allow_null=True,
         validators=[FileExtensionValidator(allowed_extensions=["xlsx"])],
     )
+    proventos = serializers.FileField(
+        required=False,
+        allow_null=True,
+        validators=[FileExtensionValidator(allowed_extensions=["xlsx"])],
+    )
 
     def validate(self, attrs: dict) -> dict:
         # Normalize duplicates so an operation isn't executed (and its report
@@ -689,11 +694,13 @@ class B3ImportSerializer(serializers.Serializer):
         negociacao = attrs.get("negociacao")
         posicao = attrs.get("posicao")
         movimentacao = attrs.get("movimentacao")
+        proventos = attrs.get("proventos")
 
         for field_name, file in (
             ("negociacao", negociacao),
             ("posicao", posicao),
             ("movimentacao", movimentacao),
+            ("proventos", proventos),
         ):
             # Extension is validated by FileExtensionValidator on the field; content is
             # validated by openpyxl downstream. Here we only cap the size before reading.
@@ -703,6 +710,8 @@ class B3ImportSerializer(serializers.Serializer):
         errors: dict = {}
         if "negociacoes" in ops and negociacao is None:
             errors["negociacao"] = "Necessário para importar negociações"
+        if "proventos" in ops and proventos is None:
+            errors["proventos"] = "Necessário para importar proventos"
         if attrs.get("create_missing_assets") and posicao is None:
             errors["posicao"] = "Necessário para criar ativos ausentes"
         if ops & {"renda_fixa", "tesouro"}:

--- a/django/variable_income_assets/tests/integrations/test__b3_handlers.py
+++ b/django/variable_income_assets/tests/integrations/test__b3_handlers.py
@@ -744,6 +744,8 @@ def test_proventos_creates_income_dedupes_and_skips_unknown(tmp_path, user):
             "INTER", "100", 1, "221.58",
         ],
         ["FOO11 - NAO CADASTRADO", d, "Rendimento", "INTER", "10", 1, "5.00"],
+        # unmapped event type -> reported as skipped, doesn't abort the import
+        ["DEBENTURE - X", d, "PAGAMENTO DE JUROS", "INTER", "1", 1, "3.00"],
     ]
     proventos_path = _build_proventos(tmp_path, rows)
 
@@ -753,6 +755,12 @@ def test_proventos_creates_income_dedupes_and_skips_unknown(tmp_path, user):
     assert len(created) == 1 and created[0]["code"] == "BBAS3"
     assert any(
         a["action"] == "skipped" and a["code"] == "FOO11" for a in report["actions"]
+    )
+    assert any(
+        a["action"] == "unsupported_event"
+        and a["code"] == "DEBENTURE"
+        and "PAGAMENTO DE JUROS" in a["reason"]
+        for a in report["actions"]
     )
 
     income = PassiveIncome.objects.get(asset__user=user, asset__code="BBAS3")

--- a/django/variable_income_assets/tests/integrations/test__b3_handlers.py
+++ b/django/variable_income_assets/tests/integrations/test__b3_handlers.py
@@ -10,10 +10,18 @@ from ...integrations.b3.handlers import (
     B3ImportError,
     import_b3_fixed_income_positions,
     import_b3_negociacoes,
+    import_b3_proventos,
     import_b3_renda_fixa_positions,
 )
-from ...models import Asset, AssetMetaData, Transaction
-from ...choices import AssetTypes, Currencies, LiquidityTypes, AssetObjectives
+from ...models import Asset, AssetMetaData, AssetReadModel, PassiveIncome, Transaction
+from ...choices import (
+    AssetObjectives,
+    AssetTypes,
+    Currencies,
+    LiquidityTypes,
+    PassiveIncomeEventTypes,
+    PassiveIncomeTypes,
+)
 from ..conftest import AssetFactory, AssetMetaDataFactory
 
 pytestmark = pytest.mark.django_db
@@ -684,3 +692,116 @@ def test_negociacoes_oversell_is_reported_not_aborted(tmp_path, user):
     assert not Transaction.objects.filter(
         asset__user=user, asset__code="BBAS3"
     ).exists()
+
+
+PROVENTOS_HEADER = [
+    "Produto",
+    "Pagamento",
+    "Tipo de Evento",
+    "Instituição",
+    "Quantidade",
+    "Preço unitário",
+    "Valor líquido",
+]
+
+
+def _build_proventos(tmp_path: Path, rows: list[list]) -> str:
+    path = tmp_path / "proventos-2026-06-12.xlsx"
+    wb = Workbook()
+    ws = wb.active
+    ws.title = "Proventos Recebidos"
+    ws.append(PROVENTOS_HEADER)
+    for row in rows:
+        ws.append(row)
+    wb.save(path)
+    return str(path)
+
+
+def test_proventos_creates_income_dedupes_and_skips_unknown(tmp_path, user):
+    from ...management.commands.sync_assets_cqrs import Command as Sync
+
+    asset = AssetFactory(
+        code="BBAS3",
+        type=AssetTypes.stock,
+        currency=Currencies.real,
+        objective=AssetObjectives.growth,
+        user=user,
+    )
+    AssetMetaDataFactory(
+        code="BBAS3",
+        type=AssetTypes.stock,
+        currency=Currencies.real,
+        current_price=Decimal("21.71"),
+        current_price_updated_at=timezone.now(),
+    )
+    Sync().handle(user_ids=[user.id])
+    yesterday = timezone.localdate() - timedelta(days=1)
+    d = yesterday.strftime("%d/%m/%Y")
+    rows = [
+        [
+            "BBAS3 - BANCO DO BRASIL S/A", d, "Juros Sobre Capital Próprio",
+            "INTER", "100", 1, "221.58",
+        ],
+        ["FOO11 - NAO CADASTRADO", d, "Rendimento", "INTER", "10", 1, "5.00"],
+    ]
+    proventos_path = _build_proventos(tmp_path, rows)
+
+    report = import_b3_proventos(user_id=user.id, dry_run=False, proventos_path=proventos_path)
+
+    created = [a for a in report["actions"] if a["action"] == "income_created"]
+    assert len(created) == 1 and created[0]["code"] == "BBAS3"
+    assert any(
+        a["action"] == "skipped" and a["code"] == "FOO11" for a in report["actions"]
+    )
+
+    income = PassiveIncome.objects.get(asset__user=user, asset__code="BBAS3")
+    assert income.type == PassiveIncomeTypes.jcp
+    assert income.event_type == PassiveIncomeEventTypes.credited
+    assert income.amount == Decimal("221.58")
+    assert income.operation_date == yesterday
+
+    # bulk_create skips the messagebus, so the read model is upserted explicitly
+    read_model = AssetReadModel.objects.get(write_model_pk=asset.id)
+    assert read_model.credited_incomes == Decimal("221.58")
+
+    # re-running dedupes: no new income for BBAS3
+    report2 = import_b3_proventos(user_id=user.id, dry_run=False, proventos_path=proventos_path)
+    assert all(
+        a["action"] != "income_created"
+        for a in report2["actions"]
+        if a["code"] == "BBAS3"
+    )
+    assert PassiveIncome.objects.filter(asset__user=user, asset__code="BBAS3").count() == 1
+    read_model.refresh_from_db()
+    assert read_model.credited_incomes == Decimal("221.58")  # unchanged
+
+
+def test_proventos_dry_run_persists_nothing(tmp_path, user):
+    from ...management.commands.sync_assets_cqrs import Command as Sync
+
+    asset = AssetFactory(
+        code="BBAS3",
+        type=AssetTypes.stock,
+        currency=Currencies.real,
+        objective=AssetObjectives.growth,
+        user=user,
+    )
+    AssetMetaDataFactory(
+        code="BBAS3",
+        type=AssetTypes.stock,
+        currency=Currencies.real,
+        current_price=Decimal("21.71"),
+        current_price_updated_at=timezone.now(),
+    )
+    Sync().handle(user_ids=[user.id])
+    d = (timezone.localdate() - timedelta(days=1)).strftime("%d/%m/%Y")
+    proventos_path = _build_proventos(
+        tmp_path, [["BBAS3 - BANCO DO BRASIL S/A", d, "Dividendo", "INTER", "100", 1, "10.00"]]
+    )
+
+    report = import_b3_proventos(user_id=user.id, dry_run=True, proventos_path=proventos_path)
+
+    assert report["actions"][0]["action"] == "income_created"
+    assert not PassiveIncome.objects.filter(asset__user=user, asset__code="BBAS3").exists()
+    # the read-model upsert is rolled back too
+    assert AssetReadModel.objects.get(write_model_pk=asset.id).credited_incomes == Decimal("0")

--- a/django/variable_income_assets/tests/integrations/test__b3_handlers.py
+++ b/django/variable_income_assets/tests/integrations/test__b3_handlers.py
@@ -2,18 +2,11 @@ from datetime import date, datetime, timedelta
 from decimal import Decimal
 from pathlib import Path
 
-import pytest
 from django.utils import timezone
+
+import pytest
 from openpyxl import Workbook
 
-from ...integrations.b3.handlers import (
-    B3ImportError,
-    import_b3_fixed_income_positions,
-    import_b3_negociacoes,
-    import_b3_proventos,
-    import_b3_renda_fixa_positions,
-)
-from ...models import Asset, AssetMetaData, AssetReadModel, PassiveIncome, Transaction
 from ...choices import (
     AssetObjectives,
     AssetTypes,
@@ -22,6 +15,14 @@ from ...choices import (
     PassiveIncomeEventTypes,
     PassiveIncomeTypes,
 )
+from ...integrations.b3.handlers import (
+    B3ImportError,
+    import_b3_fixed_income_positions,
+    import_b3_negociacoes,
+    import_b3_proventos,
+    import_b3_renda_fixa_positions,
+)
+from ...models import Asset, AssetMetaData, AssetReadModel, PassiveIncome, Transaction
 from ..conftest import AssetFactory, AssetMetaDataFactory
 
 pytestmark = pytest.mark.django_db
@@ -764,8 +765,12 @@ def test_proventos_creates_income_dedupes_and_skips_unknown(tmp_path, user):
     read_model = AssetReadModel.objects.get(write_model_pk=asset.id)
     assert read_model.credited_incomes == Decimal("221.58")
 
-    # re-running dedupes: no new income for BBAS3
+    # re-running dedupes: BBAS3 is reported as already_exists, no new income
     report2 = import_b3_proventos(user_id=user.id, dry_run=False, proventos_path=proventos_path)
+    assert any(
+        a["action"] == "already_exists" and a["code"] == "BBAS3"
+        for a in report2["actions"]
+    )
     assert all(
         a["action"] != "income_created"
         for a in report2["actions"]

--- a/django/variable_income_assets/tests/integrations/test__b3_import_api.py
+++ b/django/variable_income_assets/tests/integrations/test__b3_import_api.py
@@ -370,3 +370,51 @@ def test_service_proventos_creates_income(tmp_path, user):
     actions = result["reports"]["proventos"]["actions"]
     assert actions[0]["action"] == "income_created"
     assert PassiveIncome.objects.filter(asset__user=user, asset__code="BBAS3").exists()
+
+
+def test_service_dry_run_proventos_sees_asset_created_by_negociacoes(
+    tmp_path, user, sync_assets_read_model
+):
+    # In a dry-run preview, proventos must recognize an asset that negociações
+    # creates in the same import (both ops share one transaction, rolled back at
+    # the end) instead of reporting "ativo não cadastrado".
+    from variable_income_assets.integrations.b3.import_service import run_b3_import
+    from variable_income_assets.models import PassiveIncome
+    from variable_income_assets.tests.integrations.test__b3_handlers import (
+        _build_negociacao,
+        _build_proventos,
+        _negotiation_row,
+    )
+
+    acoes_row = [
+        "BBAS3 - BCO BRASIL S.A.", "INTER DTVM", "4038379", "BBAS3",
+        "00000000000191", "BRBBASACNOR3 - 337", "ON", "BANCO DO BRASIL S/A",
+        971, 971, "-", "-", 21.71, 21080.41,
+    ]
+    posicao_path = _build_posicao(tmp_path, [], acoes_rows=[acoes_row])
+    negociacao_path = _build_negociacao(tmp_path, [_negotiation_row(code="BBAS3")])
+    d = (timezone.localdate() - timedelta(days=1)).strftime("%d/%m/%Y")
+    proventos_path = _build_proventos(
+        tmp_path, [["BBAS3 - BANCO DO BRASIL S/A", d, "Dividendo", "INTER", "100", 1, "10.00"]]
+    )
+
+    result = run_b3_import(
+        user_id=user.id,
+        # reversed on purpose: the service must still run negociações before proventos
+        operations=["proventos", "negociacoes"],
+        dry_run=True,
+        workbook_dt=None,
+        create_missing_assets=True,
+        negociacao_file=_upload_from_path(negociacao_path, "negociacao.xlsx"),
+        posicao_file=_upload_from_path(posicao_path, "posicao-2026-04-29-12-00-00.xlsx"),
+        movimentacao_file=None,
+        proventos_file=_upload_from_path(proventos_path, "proventos-2026.xlsx"),
+    )
+
+    prov_actions = result["reports"]["proventos"]["actions"]
+    assert any(
+        a["action"] == "income_created" and a["code"] == "BBAS3" for a in prov_actions
+    )
+    # dry run: nothing persists
+    assert not Asset.objects.filter(user=user, code="BBAS3").exists()
+    assert not PassiveIncome.objects.filter(asset__user=user).exists()

--- a/django/variable_income_assets/tests/integrations/test__b3_import_api.py
+++ b/django/variable_income_assets/tests/integrations/test__b3_import_api.py
@@ -309,3 +309,64 @@ def test_endpoint_bad_file_returns_400_with_operation(client):
     )
     assert response.status_code == 400
     assert response.data["operation"] == "tesouro"
+
+
+def test_serializer_proventos_requires_file():
+    from variable_income_assets.serializers import B3ImportSerializer
+
+    serializer = B3ImportSerializer(data={"operations": ["proventos"], "dry_run": True})
+    assert not serializer.is_valid()
+    assert "proventos" in serializer.errors
+
+
+def test_service_proventos_creates_income(tmp_path, user):
+    from variable_income_assets.choices import (
+        AssetObjectives,
+        AssetTypes,
+        Currencies,
+    )
+    from variable_income_assets.integrations.b3.import_service import run_b3_import
+    from variable_income_assets.management.commands.sync_assets_cqrs import (
+        Command as Sync,
+    )
+    from variable_income_assets.models import PassiveIncome
+    from variable_income_assets.tests.conftest import AssetFactory, AssetMetaDataFactory
+    from variable_income_assets.tests.integrations.test__b3_handlers import (
+        _build_proventos,
+    )
+
+    AssetFactory(
+        code="BBAS3",
+        type=AssetTypes.stock,
+        currency=Currencies.real,
+        objective=AssetObjectives.growth,
+        user=user,
+    )
+    AssetMetaDataFactory(
+        code="BBAS3",
+        type=AssetTypes.stock,
+        currency=Currencies.real,
+        current_price=Decimal("21.71"),
+        current_price_updated_at=timezone.now(),
+    )
+    Sync().handle(user_ids=[user.id])
+    d = (timezone.localdate() - timedelta(days=1)).strftime("%d/%m/%Y")
+    path = _build_proventos(
+        tmp_path, [["BBAS3 - BANCO DO BRASIL S/A", d, "Dividendo", "INTER", "100", 1, "10.00"]]
+    )
+    proventos = _upload_from_path(path, "proventos-2026.xlsx")
+
+    result = run_b3_import(
+        user_id=user.id,
+        operations=["proventos"],
+        dry_run=False,
+        workbook_dt=None,
+        negociacao_file=None,
+        posicao_file=None,
+        movimentacao_file=None,
+        proventos_file=proventos,
+    )
+
+    actions = result["reports"]["proventos"]["actions"]
+    assert actions[0]["action"] == "income_created"
+    assert PassiveIncome.objects.filter(asset__user=user, asset__code="BBAS3").exists()

--- a/django/variable_income_assets/views.py
+++ b/django/variable_income_assets/views.py
@@ -158,6 +158,7 @@ class AssetViewSet(
                 negociacao_file=data.get("negociacao"),
                 posicao_file=data.get("posicao"),
                 movimentacao_file=data.get("movimentacao"),
+                proventos_file=data.get("proventos"),
             )
         except B3ImportOperationError as exc:
             return Response(exc.as_dict(), status=HTTP_400_BAD_REQUEST)

--- a/react/src/pages/private/Assets/ImportB3/B3ImportReport.tsx
+++ b/react/src/pages/private/Assets/ImportB3/B3ImportReport.tsx
@@ -20,9 +20,11 @@ import TableRow from "@mui/material/TableRow";
 import Typography from "@mui/material/Typography";
 
 import { Colors, getColor } from "../../../../design-system";
+import { AssetCurrencies, AssetCurrencyMap } from "../consts";
 import { priceDiffPct } from "./logic";
 import type {
   B3ActionEntry,
+  B3Income,
   B3ImportResponse,
   B3Operation,
   B3OperationReport,
@@ -32,16 +34,38 @@ const OPERATION_LABELS: Record<B3Operation, string> = {
   negociacoes: "Negociações",
   renda_fixa: "Renda Fixa",
   tesouro: "Tesouro",
+  proventos: "Proventos",
 };
 
 const ACTION_LABELS: Record<string, string> = {
   created: "Ativo criado",
   asset_created: "Ativo criado",
   transaction_created: "Transação criada",
+  income_created: "Provento criado",
   price_updated: "Preço atualizado",
   price_skipped: "Preço mantido",
   skipped: "Ignorado",
   error: "Erro",
+};
+
+const INCOME_TYPE_LABELS: Record<string, string> = {
+  DIVIDEND: "Dividendo",
+  JCP: "JCP",
+  INCOME: "Rendimento",
+  REIMBURSEMENT: "Reembolso",
+};
+
+// "JCP · R$221,58 · 11/06/2026"
+const formatIncome = (income: B3Income): string => {
+  const typeLabel = INCOME_TYPE_LABELS[income.type] ?? income.type;
+  const symbol =
+    AssetCurrencyMap[income.currency as AssetCurrencies]?.symbol ?? "";
+  const amount = Number(income.amount).toLocaleString("pt-BR", {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  });
+  const [y, m, d] = income.operation_date.split("-");
+  return `${typeLabel} · ${symbol}${amount} · ${d}/${m}/${y}`;
 };
 
 // These chips label an outcome (not a status), so render them as outlined tags
@@ -51,6 +75,7 @@ const COLOR_BY_ACTION: Record<string, Colors> = {
   created: Colors.brand,
   asset_created: Colors.brand,
   transaction_created: Colors.brand,
+  income_created: Colors.brand,
   price_updated: Colors.brand,
   price_skipped: Colors.neutral300,
   skipped: Colors.neutral300,
@@ -75,6 +100,8 @@ const detailText = (entry: B3ActionEntry): string => {
   if (entry.action === "skipped") return entry.reason ?? "";
   if (entry.action === "price_skipped") return entry.reason ?? "";
   if (entry.action === "error") return entry.reason ?? "";
+  if (entry.action === "income_created" && entry.income)
+    return formatIncome(entry.income);
   if (entry.action === "created" || entry.action === "asset_created")
     return `#${entry.asset_pk ?? "—"}`;
   return "";

--- a/react/src/pages/private/Assets/ImportB3/B3ImportReport.tsx
+++ b/react/src/pages/private/Assets/ImportB3/B3ImportReport.tsx
@@ -1,25 +1,25 @@
-import { Fragment, useState } from "react";
+import { useMemo, useState } from "react";
 
-import CloseIcon from "@mui/icons-material/Close";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
-import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
-import KeyboardArrowRightIcon from "@mui/icons-material/KeyboardArrowRight";
-import OpenInFullIcon from "@mui/icons-material/OpenInFull";
+import FilterListIcon from "@mui/icons-material/FilterList";
 import Accordion from "@mui/material/Accordion";
 import AccordionDetails from "@mui/material/AccordionDetails";
 import AccordionSummary from "@mui/material/AccordionSummary";
-import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
+import Checkbox from "@mui/material/Checkbox";
 import Chip from "@mui/material/Chip";
-import Drawer from "@mui/material/Drawer";
 import FormControlLabel from "@mui/material/FormControlLabel";
-import IconButton from "@mui/material/IconButton";
+import Menu from "@mui/material/Menu";
 import Stack from "@mui/material/Stack";
 import Switch from "@mui/material/Switch";
-import Table from "@mui/material/Table";
-import TableBody from "@mui/material/TableBody";
-import TableCell from "@mui/material/TableCell";
-import TableRow from "@mui/material/TableRow";
 import Typography from "@mui/material/Typography";
+
+import {
+  MaterialReactTable,
+  useMaterialReactTable,
+  type MRT_ColumnDef as Column,
+  type MRT_Row as Row,
+} from "material-react-table";
 
 import { Colors, getColor } from "../../../../design-system";
 import { AssetCurrencies, AssetCurrencyMap } from "../consts";
@@ -30,6 +30,7 @@ import type {
   B3ImportResponse,
   B3Operation,
   B3OperationReport,
+  B3Transaction,
 } from "./types";
 
 const OPERATION_LABELS: Record<B3Operation, string> = {
@@ -48,17 +49,28 @@ const ACTION_LABELS: Record<string, string> = {
   price_skipped: "Preço mantido",
   skipped: "Ignorado",
   already_exists: "Já cadastrado",
+  unsupported_event: "Tipo não suportado",
   error: "Erro",
 };
 
 // Rows skipped only because the record already exists in the DB.
 const ALREADY_EXISTS = "already_exists";
 
+const TRANSACTION_CREATED = "transaction_created";
+const isAssetCreated = (action: string) =>
+  action === "asset_created" || action === "created";
+
 const INCOME_TYPE_LABELS: Record<string, string> = {
   DIVIDEND: "Dividendo",
   JCP: "JCP",
   INCOME: "Rendimento",
   REIMBURSEMENT: "Reembolso",
+};
+
+// "2026-06-11" -> "11/06/2026"
+const formatDateBr = (iso: string): string => {
+  const [y, m, d] = iso.split("-");
+  return `${d}/${m}/${y}`;
 };
 
 // "JCP · R$221,58 · 11/06/2026"
@@ -70,8 +82,18 @@ const formatIncome = (income: B3Income): string => {
     minimumFractionDigits: 2,
     maximumFractionDigits: 2,
   });
-  const [y, m, d] = income.operation_date.split("-");
-  return `${typeLabel} · ${symbol}${amount} · ${d}/${m}/${y}`;
+  return `${typeLabel} · ${symbol}${amount} · ${formatDateBr(income.operation_date)}`;
+};
+
+const TX_ACTION_LABELS: Record<string, string> = {
+  BUY: "Compra",
+  SELL: "Venda",
+};
+
+// "Compra 100 @ 21.71 em 11/06/2026"
+const formatTransaction = (tx: B3Transaction): string => {
+  const action = TX_ACTION_LABELS[tx.action] ?? tx.action;
+  return `${action} ${tx.quantity} @ ${tx.price} em ${formatDateBr(tx.operation_date)}`;
 };
 
 // These chips label an outcome (not a status), so render them as outlined tags
@@ -86,6 +108,7 @@ const COLOR_BY_ACTION: Record<string, Colors> = {
   price_skipped: Colors.neutral300,
   skipped: Colors.neutral300,
   already_exists: Colors.neutral300,
+  unsupported_event: Colors.neutral300,
   error: Colors.danger200,
 };
 
@@ -107,11 +130,10 @@ const detailText = (entry: B3ActionEntry): string => {
   if (entry.action === "skipped") return entry.reason ?? "";
   if (entry.action === "price_skipped") return entry.reason ?? "";
   if (entry.action === ALREADY_EXISTS) return entry.reason ?? "";
+  if (entry.action === "unsupported_event") return entry.reason ?? "";
   if (entry.action === "error") return entry.reason ?? "";
   if (entry.action === "income_created" && entry.income)
     return formatIncome(entry.income);
-  if (entry.action === "created" || entry.action === "asset_created")
-    return `#${entry.asset_pk ?? "—"}`;
   return "";
 };
 
@@ -137,57 +159,121 @@ const PriceUpdatedDetail = ({ entry }: { entry: B3ActionEntry }) => {
   );
 };
 
-const ActionRow = ({ entry }: { entry: B3ActionEntry }) => {
-  const [open, setOpen] = useState(false);
-  const subTransactions =
-    entry.transactions ?? (entry.transaction ? [entry.transaction] : []);
-  const expandable = subTransactions.length > 0;
+type ReportRow = B3ActionEntry & { subRows?: ReportRow[] };
 
+// Synthetic parent for an asset that has events (transactions/incomes) but no
+// asset-level row in this operation (e.g. an existing asset in proventos).
+const SYNTHETIC_ASSET = "asset";
+// Asset-level rows that can head a group.
+const ASSET_LEVEL = new Set([
+  "asset_created",
+  "created",
+  "price_updated",
+  "price_skipped",
+]);
+// Per-event rows that nest under their asset.
+const EVENT_LEVEL = new Set([TRANSACTION_CREATED, "income_created", ALREADY_EXISTS]);
+const ISSUE_LEVEL = new Set(["skipped", "error"]);
+
+// Aggregate an operation's actions by asset: every same-code row hangs off a
+// single asset parent (its transactions, incomes, etc. as nested subRows). When
+// the op has no asset-level row for that code, synthesize one. Issues
+// (skipped/error) and code-less rows stay standalone.
+const buildReportRows = (actions: B3ActionEntry[]): ReportRow[] => {
+  const order: string[] = [];
+  const byCode = new Map<string, B3ActionEntry[]>();
+
+  for (const a of actions) {
+    const code = a.code ?? "";
+    if (!byCode.has(code)) {
+      byCode.set(code, []);
+      order.push(code);
+    }
+    byCode.get(code)!.push(a);
+  }
+
+  const rows: ReportRow[] = [];
+  for (const code of order) {
+    const group = byCode.get(code)!;
+    if (!code) {
+      group.forEach((a) => rows.push({ ...a }));
+      continue;
+    }
+
+    const parents = group.filter((a) => ASSET_LEVEL.has(a.action));
+    const issues = group.filter((a) => ISSUE_LEVEL.has(a.action));
+    const events: B3ActionEntry[] = [];
+    for (const a of group) {
+      if (EVENT_LEVEL.has(a.action)) events.push(a);
+      // renda_fixa/tesouro bundle their transactions on the "created" entry
+      if (isAssetCreated(a.action) && a.transactions?.length) {
+        a.transactions.forEach((tx) =>
+          events.push({ action: TRANSACTION_CREATED, code, transaction: tx }),
+        );
+      }
+    }
+
+    if (parents.length > 0) {
+      const [parent, ...extra] = parents;
+      rows.push({ ...parent, subRows: events });
+      extra.forEach((p) => rows.push({ ...p }));
+    } else if (events.length > 0) {
+      rows.push({
+        action: SYNTHETIC_ASSET,
+        code,
+        description: events.find((e) => e.description)?.description,
+        asset_pk: events.find((e) => e.asset_pk)?.asset_pk,
+        subRows: events,
+      });
+    }
+    issues.forEach((i) => rows.push({ ...i }));
+  }
+
+  return rows;
+};
+
+const CodeCell = ({ row }: { row: Row<ReportRow> }) => {
+  if (row.depth > 0) return null; // nested transactions inherit the asset's code
+  const entry = row.original;
   return (
-    <Fragment>
-      <TableRow>
-        <TableCell padding="checkbox">
-          {expandable && (
-            <IconButton size="small" onClick={() => setOpen((v) => !v)}>
-              {open ? <KeyboardArrowDownIcon /> : <KeyboardArrowRightIcon />}
-            </IconButton>
-          )}
-        </TableCell>
-        <TableCell>
-          <Stack spacing={0}>
-            <span>{entry.code ?? "—"}</span>
-            {entry.description && (
-              <Typography variant="caption" color={getColor(Colors.neutral300)}>
-                {entry.description}
-              </Typography>
-            )}
-          </Stack>
-        </TableCell>
-        <TableCell>
-          <ActionChip action={entry.action} label={actionLabel(entry.action)} />
-        </TableCell>
-        <TableCell>
-          {entry.action === "price_updated" ? (
-            <PriceUpdatedDetail entry={entry} />
-          ) : (
-            detailText(entry)
-          )}
-        </TableCell>
-      </TableRow>
-      {open &&
-        subTransactions.map((tx, i) => (
-          <TableRow key={i}>
-            <TableCell />
-            <TableCell colSpan={3}>
-              <Typography variant="body2" color={getColor(Colors.neutral300)}>
-                {tx.action} {tx.quantity} @ {tx.price} em {tx.operation_date}
-              </Typography>
-            </TableCell>
-          </TableRow>
-        ))}
-    </Fragment>
+    <Stack spacing={0}>
+      <span>{entry.code ?? "—"}</span>
+      {entry.description && (
+        <Typography variant="caption" color={getColor(Colors.neutral300)}>
+          {entry.description}
+        </Typography>
+      )}
+    </Stack>
   );
 };
+
+const DetailCell = ({ row }: { row: Row<ReportRow> }) => {
+  const entry = row.original;
+  if (entry.action === SYNTHETIC_ASSET) return null;
+  if (entry.action === TRANSACTION_CREATED && entry.transaction)
+    return <>{formatTransaction(entry.transaction)}</>;
+  if (entry.action === "price_updated") return <PriceUpdatedDetail entry={entry} />;
+  return <>{detailText(entry)}</>;
+};
+
+const REPORT_COLUMNS: Column<ReportRow>[] = [
+  { id: "code", header: "Ativo", accessorFn: (r) => r.code ?? "", Cell: CodeCell },
+  {
+    id: "action",
+    header: "Ação",
+    accessorFn: (r) => r.action,
+    size: 160,
+    // The synthetic asset parent is just a grouping header, so it has no chip.
+    Cell: ({ row }) =>
+      row.original.action === SYNTHETIC_ASSET ? null : (
+        <ActionChip
+          action={row.original.action}
+          label={actionLabel(row.original.action)}
+        />
+      ),
+  },
+  { id: "detail", header: "Detalhe", accessorFn: () => "", Cell: DetailCell },
+];
 
 const summaryChips = (actions: B3ActionEntry[]) => {
   const counts: Record<string, number> = {};
@@ -215,158 +301,227 @@ const StatusPill = ({ dryRun }: { dryRun: boolean }) => (
   />
 );
 
-const OperationContent = ({
-  report,
-  hideExisting,
+// Action types the report can filter out, in display order. "unsupported_event"
+// is intentionally absent — those rows are never hidden.
+const FILTERABLE_ACTIONS: { action: string; label: string }[] = [
+  { action: "skipped", label: "Ignorados" },
+  { action: "price_skipped", label: "Preço mantido" },
+  { action: ALREADY_EXISTS, label: "Já cadastrados" },
+];
+
+const ReportFilterMenu = ({
+  present,
+  hidden,
+  onToggle,
 }: {
-  report: B3OperationReport;
-  hideExisting: boolean;
+  present: Set<string>;
+  hidden: Set<string>;
+  onToggle: (action: string) => void;
 }) => {
-  // Summary chips count everything; the table can hide already-in-DB rows.
-  const rows = hideExisting
-    ? report.actions.filter((a) => a.action !== ALREADY_EXISTS)
-    : report.actions;
+  const [anchor, setAnchor] = useState<null | HTMLElement>(null);
+  const items = FILTERABLE_ACTIONS.filter((f) => present.has(f.action));
+  if (items.length === 0) return null;
+  const count = items.filter((f) => hidden.has(f.action)).length;
   return (
-    <Stack spacing={1}>
-      <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
-        {summaryChips(report.actions)}
-        <Chip
-          size="small"
-          variant="outlined"
-          label={`Total: ${report.actions.length}`}
-          sx={{
-            borderColor: getColor(Colors.neutral300),
-            color: getColor(Colors.neutral300),
-          }}
-        />
-      </Stack>
-      {rows.length > 0 ? (
-        <Table size="small">
-          <TableBody>
-            {rows.map((entry, i) => (
-              <ActionRow key={i} entry={entry} />
-            ))}
-          </TableBody>
-        </Table>
-      ) : (
-        <Typography variant="body2" color={getColor(Colors.neutral300)}>
-          Nenhuma ação.
-        </Typography>
-      )}
-    </Stack>
+    <>
+      <Button
+        size="small"
+        startIcon={<FilterListIcon />}
+        onClick={(e) => setAnchor(e.currentTarget)}
+        sx={{ color: getColor(Colors.neutral300) }}
+      >
+        {`Filtrar${count ? ` (${count})` : ""}`}
+      </Button>
+      <Menu
+        anchorEl={anchor}
+        open={anchor !== null}
+        onClose={() => setAnchor(null)}
+      >
+        <Stack sx={{ px: 2, py: 0.5 }}>
+          <Typography variant="caption" color={getColor(Colors.neutral300)}>
+            Mostrar
+          </Typography>
+          {items.map((f) => (
+            <FormControlLabel
+              key={f.action}
+              control={
+                <Checkbox
+                  size="small"
+                  checked={!hidden.has(f.action)}
+                  onChange={() => onToggle(f.action)}
+                />
+              }
+              label={f.label}
+            />
+          ))}
+        </Stack>
+      </Menu>
+    </>
   );
 };
+
+// An asset-aggregated table for a list of actions (one operation, or all of them
+// merged). Summary chips count everything; the table hides the filtered actions.
+const ReportTable = ({
+  actions,
+  hidden,
+}: {
+  actions: B3ActionEntry[];
+  hidden: Set<string>;
+}) => {
+  const data = useMemo(
+    () => buildReportRows(actions.filter((a) => !hidden.has(a.action))),
+    [actions, hidden],
+  );
+
+  const table = useMaterialReactTable({
+    columns: REPORT_COLUMNS,
+    data,
+    enableExpanding: true,
+    getSubRows: (row) => row.subRows,
+    filterFromLeafRows: false,
+    enableExpandAll: false,
+    enableSorting: false,
+    enablePagination: false,
+    enableBottomToolbar: false,
+    enableTopToolbar: false,
+    enableTableHead: false,
+    enableColumnActions: false,
+    initialState: { expanded: true },
+    mrtTheme: { baseBackgroundColor: getColor(Colors.neutral600) },
+    muiTablePaperProps: {
+      elevation: 0,
+      sx: { backgroundImage: "none" },
+    },
+    muiExpandButtonProps: { size: "small", sx: { p: 0 } },
+    displayColumnDefOptions: {
+      "mrt-row-expand": {
+        header: "",
+        size: 16,
+        minSize: 8,
+        grow: false,
+        muiTableBodyCellProps: { sx: { px: 0 } },
+        muiTableHeadCellProps: { sx: { px: 0 } },
+      },
+    },
+  });
+
+  if (data.length === 0)
+    return (
+      <Typography variant="body2" color={getColor(Colors.neutral300)}>
+        Nenhuma ação.
+      </Typography>
+    );
+  return <MaterialReactTable table={table} />;
+};
+
+const ActionsSummary = ({ actions }: { actions: B3ActionEntry[] }) => (
+  <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
+    {summaryChips(actions)}
+    <Chip
+      size="small"
+      variant="outlined"
+      label={`Total: ${actions.length}`}
+      sx={{
+        borderColor: getColor(Colors.neutral300),
+        color: getColor(Colors.neutral300),
+      }}
+    />
+  </Stack>
+);
+
+const OperationContent = ({
+  report,
+  hidden,
+}: {
+  report: B3OperationReport;
+  hidden: Set<string>;
+}) => (
+  <Stack spacing={1}>
+    <ActionsSummary actions={report.actions} />
+    <ReportTable actions={report.actions} hidden={hidden} />
+  </Stack>
+);
 
 const OperationSection = ({
   op,
   report,
-  hideExisting,
-  onExpand,
+  hidden,
 }: {
   op: B3Operation;
   report: B3OperationReport;
-  hideExisting: boolean;
-  onExpand: () => void;
+  hidden: Set<string>;
 }) => (
   <Accordion defaultExpanded>
     <AccordionSummary expandIcon={<ExpandMoreIcon />}>
       <Stack direction="row" spacing={1} alignItems="center" sx={{ flex: 1 }}>
         <Typography>{OPERATION_LABELS[op]}</Typography>
         <StatusPill dryRun={report.dry_run} />
-        <Box sx={{ flexGrow: 1 }} />
-        <IconButton
-          component="div"
-          role="button"
-          size="small"
-          aria-label="Expandir"
-          onClick={(e) => {
-            e.stopPropagation();
-            onExpand();
-          }}
-        >
-          <OpenInFullIcon fontSize="small" />
-        </IconButton>
       </Stack>
     </AccordionSummary>
     <AccordionDetails>
-      <OperationContent report={report} hideExisting={hideExisting} />
+      <OperationContent report={report} hidden={hidden} />
     </AccordionDetails>
   </Accordion>
 );
 
 const B3ImportReport = ({ response }: { response: B3ImportResponse }) => {
-  const [expandedOp, setExpandedOp] = useState<B3Operation | null>(null);
-  const [hideExisting, setHideExisting] = useState(true);
+  const [aggregateAll, setAggregateAll] = useState(false);
+  // Já cadastrados are hidden by default; the other categories start visible.
+  const [hidden, setHidden] = useState<Set<string>>(
+    () => new Set([ALREADY_EXISTS]),
+  );
+  const toggleHidden = (action: string) =>
+    setHidden((prev) => {
+      const next = new Set(prev);
+      next.has(action) ? next.delete(action) : next.add(action);
+      return next;
+    });
+
   const ops = (Object.keys(response.reports) as B3Operation[]).filter(
     (op) => response.reports[op],
   );
-  const expandedReport = expandedOp ? response.reports[expandedOp] : null;
-  const hasExisting = ops.some((op) =>
-    response.reports[op]!.actions.some((a) => a.action === ALREADY_EXISTS),
-  );
+  const allActions = ops.flatMap((op) => response.reports[op]!.actions);
+  const present = new Set(allActions.map((a) => a.action));
 
   return (
-    <>
-      <Stack spacing={1}>
-        {hasExisting && (
-          <FormControlLabel
-            sx={{ alignSelf: "flex-start" }}
-            control={
-              <Switch
-                checked={hideExisting}
-                onChange={(e) => setHideExisting(e.target.checked)}
-              />
-            }
-            label="Ocultar já cadastrados"
-          />
-        )}
-        {ops.map((op) => (
+    <Stack spacing={1}>
+      <Stack direction="row" spacing={2} alignItems="center" flexWrap="wrap" useFlexGap>
+        <FormControlLabel
+          control={
+            <Switch
+              checked={aggregateAll}
+              onChange={(e) => setAggregateAll(e.target.checked)}
+            />
+          }
+          label="Agregar por ativo"
+        />
+        <ReportFilterMenu
+          present={present}
+          hidden={hidden}
+          onToggle={toggleHidden}
+        />
+      </Stack>
+      {aggregateAll ? (
+        <Stack spacing={1}>
+          <Stack direction="row" spacing={1} alignItems="center">
+            <Typography>Todos os ativos</Typography>
+            <StatusPill dryRun={response.dry_run} />
+          </Stack>
+          <ActionsSummary actions={allActions} />
+          <ReportTable actions={allActions} hidden={hidden} />
+        </Stack>
+      ) : (
+        ops.map((op) => (
           <OperationSection
             key={op}
             op={op}
             report={response.reports[op]!}
-            hideExisting={hideExisting}
-            onExpand={() => setExpandedOp(op)}
+            hidden={hidden}
           />
-        ))}
-      </Stack>
-      <Drawer
-        open={expandedOp !== null}
-        onClose={() => setExpandedOp(null)}
-        anchor="right"
-        slotProps={{
-          paper: {
-            sx: {
-              width: "90vw",
-              maxWidth: 1200,
-              backgroundColor: getColor(Colors.neutral600),
-              backgroundImage: "none",
-            },
-          },
-        }}
-      >
-        {expandedOp && expandedReport && (
-          <Stack spacing={2} sx={{ p: 3 }}>
-            <Stack direction="row" spacing={1} alignItems="center">
-              <Typography variant="h6">{OPERATION_LABELS[expandedOp]}</Typography>
-              <StatusPill dryRun={expandedReport.dry_run} />
-              <Box sx={{ flexGrow: 1 }} />
-              <IconButton
-                size="small"
-                aria-label="Fechar"
-                onClick={() => setExpandedOp(null)}
-              >
-                <CloseIcon />
-              </IconButton>
-            </Stack>
-            <OperationContent
-              report={expandedReport}
-              hideExisting={hideExisting}
-            />
-          </Stack>
-        )}
-      </Drawer>
-    </>
+        ))
+      )}
+    </Stack>
   );
 };
 

--- a/react/src/pages/private/Assets/ImportB3/B3ImportReport.tsx
+++ b/react/src/pages/private/Assets/ImportB3/B3ImportReport.tsx
@@ -11,8 +11,10 @@ import AccordionSummary from "@mui/material/AccordionSummary";
 import Box from "@mui/material/Box";
 import Chip from "@mui/material/Chip";
 import Drawer from "@mui/material/Drawer";
+import FormControlLabel from "@mui/material/FormControlLabel";
 import IconButton from "@mui/material/IconButton";
 import Stack from "@mui/material/Stack";
+import Switch from "@mui/material/Switch";
 import Table from "@mui/material/Table";
 import TableBody from "@mui/material/TableBody";
 import TableCell from "@mui/material/TableCell";
@@ -45,8 +47,12 @@ const ACTION_LABELS: Record<string, string> = {
   price_updated: "Preço atualizado",
   price_skipped: "Preço mantido",
   skipped: "Ignorado",
+  already_exists: "Já cadastrado",
   error: "Erro",
 };
+
+// Rows skipped only because the record already exists in the DB.
+const ALREADY_EXISTS = "already_exists";
 
 const INCOME_TYPE_LABELS: Record<string, string> = {
   DIVIDEND: "Dividendo",
@@ -79,6 +85,7 @@ const COLOR_BY_ACTION: Record<string, Colors> = {
   price_updated: Colors.brand,
   price_skipped: Colors.neutral300,
   skipped: Colors.neutral300,
+  already_exists: Colors.neutral300,
   error: Colors.danger200,
 };
 
@@ -99,6 +106,7 @@ const ActionChip = ({ action, label }: { action: string; label: string }) => {
 const detailText = (entry: B3ActionEntry): string => {
   if (entry.action === "skipped") return entry.reason ?? "";
   if (entry.action === "price_skipped") return entry.reason ?? "";
+  if (entry.action === ALREADY_EXISTS) return entry.reason ?? "";
   if (entry.action === "error") return entry.reason ?? "";
   if (entry.action === "income_created" && entry.income)
     return formatIncome(entry.income);
@@ -207,43 +215,57 @@ const StatusPill = ({ dryRun }: { dryRun: boolean }) => (
   />
 );
 
-const OperationContent = ({ report }: { report: B3OperationReport }) => (
-  <Stack spacing={1}>
-    <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
-      {summaryChips(report.actions)}
-      <Chip
-        size="small"
-        variant="outlined"
-        label={`Total: ${report.actions.length}`}
-        sx={{
-          borderColor: getColor(Colors.neutral300),
-          color: getColor(Colors.neutral300),
-        }}
-      />
+const OperationContent = ({
+  report,
+  hideExisting,
+}: {
+  report: B3OperationReport;
+  hideExisting: boolean;
+}) => {
+  // Summary chips count everything; the table can hide already-in-DB rows.
+  const rows = hideExisting
+    ? report.actions.filter((a) => a.action !== ALREADY_EXISTS)
+    : report.actions;
+  return (
+    <Stack spacing={1}>
+      <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
+        {summaryChips(report.actions)}
+        <Chip
+          size="small"
+          variant="outlined"
+          label={`Total: ${report.actions.length}`}
+          sx={{
+            borderColor: getColor(Colors.neutral300),
+            color: getColor(Colors.neutral300),
+          }}
+        />
+      </Stack>
+      {rows.length > 0 ? (
+        <Table size="small">
+          <TableBody>
+            {rows.map((entry, i) => (
+              <ActionRow key={i} entry={entry} />
+            ))}
+          </TableBody>
+        </Table>
+      ) : (
+        <Typography variant="body2" color={getColor(Colors.neutral300)}>
+          Nenhuma ação.
+        </Typography>
+      )}
     </Stack>
-    {report.actions.length > 0 ? (
-      <Table size="small">
-        <TableBody>
-          {report.actions.map((entry, i) => (
-            <ActionRow key={i} entry={entry} />
-          ))}
-        </TableBody>
-      </Table>
-    ) : (
-      <Typography variant="body2" color={getColor(Colors.neutral300)}>
-        Nenhuma ação.
-      </Typography>
-    )}
-  </Stack>
-);
+  );
+};
 
 const OperationSection = ({
   op,
   report,
+  hideExisting,
   onExpand,
 }: {
   op: B3Operation;
   report: B3OperationReport;
+  hideExisting: boolean;
   onExpand: () => void;
 }) => (
   <Accordion defaultExpanded>
@@ -267,26 +289,43 @@ const OperationSection = ({
       </Stack>
     </AccordionSummary>
     <AccordionDetails>
-      <OperationContent report={report} />
+      <OperationContent report={report} hideExisting={hideExisting} />
     </AccordionDetails>
   </Accordion>
 );
 
 const B3ImportReport = ({ response }: { response: B3ImportResponse }) => {
   const [expandedOp, setExpandedOp] = useState<B3Operation | null>(null);
+  const [hideExisting, setHideExisting] = useState(true);
   const ops = (Object.keys(response.reports) as B3Operation[]).filter(
     (op) => response.reports[op],
   );
   const expandedReport = expandedOp ? response.reports[expandedOp] : null;
+  const hasExisting = ops.some((op) =>
+    response.reports[op]!.actions.some((a) => a.action === ALREADY_EXISTS),
+  );
 
   return (
     <>
       <Stack spacing={1}>
+        {hasExisting && (
+          <FormControlLabel
+            sx={{ alignSelf: "flex-start" }}
+            control={
+              <Switch
+                checked={hideExisting}
+                onChange={(e) => setHideExisting(e.target.checked)}
+              />
+            }
+            label="Ocultar já cadastrados"
+          />
+        )}
         {ops.map((op) => (
           <OperationSection
             key={op}
             op={op}
             report={response.reports[op]!}
+            hideExisting={hideExisting}
             onExpand={() => setExpandedOp(op)}
           />
         ))}
@@ -320,7 +359,10 @@ const B3ImportReport = ({ response }: { response: B3ImportResponse }) => {
                 <CloseIcon />
               </IconButton>
             </Stack>
-            <OperationContent report={expandedReport} />
+            <OperationContent
+              report={expandedReport}
+              hideExisting={hideExisting}
+            />
           </Stack>
         )}
       </Drawer>

--- a/react/src/pages/private/Assets/ImportB3/FileDropArea.tsx
+++ b/react/src/pages/private/Assets/ImportB3/FileDropArea.tsx
@@ -26,8 +26,10 @@ const FileDropArea = ({ onFiles }: { onFiles: (files: FileList) => void }) => {
         display: "flex",
         flexDirection: "column",
         alignItems: "center",
+        justifyContent: "center",
         gap: 1,
         p: 3,
+        minHeight: 280,
         borderRadius: 2,
         cursor: "pointer",
         textAlign: "center",
@@ -45,7 +47,7 @@ const FileDropArea = ({ onFiles }: { onFiles: (files: FileList) => void }) => {
           e.target.value = ""; // allow re-selecting the same files
         }}
       />
-      <UploadFileIcon />
+      <UploadFileIcon sx={{ fontSize: 48 }} />
       <Typography variant="body2">
         Arraste os arquivos da B3 aqui ou clique para selecionar
       </Typography>

--- a/react/src/pages/private/Assets/ImportB3/FileDropArea.tsx
+++ b/react/src/pages/private/Assets/ImportB3/FileDropArea.tsx
@@ -50,7 +50,7 @@ const FileDropArea = ({ onFiles }: { onFiles: (files: FileList) => void }) => {
         Arraste os arquivos da B3 aqui ou clique para selecionar
       </Typography>
       <Typography variant="caption" color={getColor(Colors.neutral300)}>
-        negociação, posição e/ou movimentação (.xlsx)
+        negociação, posição, movimentação e/ou proventos (.xlsx)
       </Typography>
     </Box>
   );

--- a/react/src/pages/private/Assets/ImportB3/index.tsx
+++ b/react/src/pages/private/Assets/ImportB3/index.tsx
@@ -1,14 +1,19 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 
 import CloseIcon from "@mui/icons-material/Close";
 import Button from "@mui/material/Button";
 import Checkbox from "@mui/material/Checkbox";
 import CircularProgress from "@mui/material/CircularProgress";
-import Divider from "@mui/material/Divider";
-import Drawer from "@mui/material/Drawer";
+import Dialog from "@mui/material/Dialog";
+import DialogActions from "@mui/material/DialogActions";
+import DialogContent from "@mui/material/DialogContent";
+import DialogTitle from "@mui/material/DialogTitle";
 import FormControlLabel from "@mui/material/FormControlLabel";
 import IconButton from "@mui/material/IconButton";
 import Stack from "@mui/material/Stack";
+import Step from "@mui/material/Step";
+import StepLabel from "@mui/material/StepLabel";
+import Stepper from "@mui/material/Stepper";
 import Switch from "@mui/material/Switch";
 import Typography from "@mui/material/Typography";
 import { AdapterDateFns } from "@mui/x-date-pickers/AdapterDateFnsV3";
@@ -30,7 +35,6 @@ import B3ImportReport from "./B3ImportReport";
 import FileDropArea from "./FileDropArea";
 import {
   classifyB3File,
-  computeSignature,
   isCreateMissingEnabled,
   isOperationEnabled,
   parseWorkbookDtFromFilename,
@@ -38,6 +42,8 @@ import {
   type B3Files,
 } from "./logic";
 import type { B3ImportResponse, B3Operation } from "./types";
+
+const STEPS = ["Configurar", "Resultado"];
 
 const OPERATIONS: { op: B3Operation; label: string }[] = [
   { op: "negociacoes", label: "Negociações" },
@@ -67,16 +73,13 @@ const B3ImportDrawer = ({
   open: boolean;
   onClose: () => void;
 }) => {
+  const [activeStep, setActiveStep] = useState(0);
   const [files, setFiles] = useState<B3Files>(EMPTY_FILES);
   const [unrecognized, setUnrecognized] = useState<string[]>([]);
   const [selectedOps, setSelectedOps] = useState<B3Operation[]>([]);
   const [workbookDt, setWorkbookDt] = useState<Date | null>(null);
-  const [createMissingAssets, setCreateMissingAssets] = useState(false);
-  const [dryRun, setDryRun] = useState(true);
+  const [createMissingAssets, setCreateMissingAssets] = useState(true);
   const [report, setReport] = useState<B3ImportResponse | null>(null);
-  const [previewedSignature, setPreviewedSignature] = useState<string | null>(
-    null,
-  );
 
   const queryClient = useQueryClient();
   const { invalidate: invalidateAssetsReportsQueries } =
@@ -99,14 +102,10 @@ const B3ImportDrawer = ({
     if (!createMissingEnabled) setCreateMissingAssets(false);
   }, [createMissingEnabled]);
 
-  const currentSignature = useMemo(
-    () => computeSignature(files, selectedOps, workbookDt, createMissingAssets),
-    [files, selectedOps, workbookDt, createMissingAssets],
-  );
-
   const needsWorkbookDt = selectedOps.some(
     (op) => op === "renda_fixa" || op === "tesouro",
   );
+  const hasAnyFile = Object.values(files).some(Boolean);
 
   // Route a batch of dropped/selected files to their slots by filename.
   const handleFiles = (fileList: FileList) => {
@@ -133,17 +132,16 @@ const B3ImportDrawer = ({
   const clearSlot = (slot: B3FileSlot) =>
     setFiles((prev) => ({ ...prev, [slot]: null }));
 
-  // Wipe everything once the drawer has finished sliding out (avoids a flash of
+  // Wipe everything once the dialog has finished closing (avoids a flash of
   // cleared fields during the close animation).
   const resetState = () => {
+    setActiveStep(0);
     setFiles(EMPTY_FILES);
     setUnrecognized([]);
     setSelectedOps([]);
     setWorkbookDt(null);
     setCreateMissingAssets(false);
-    setDryRun(true);
     setReport(null);
-    setPreviewedSignature(null);
   };
 
   const toggleOp = (op: B3Operation) =>
@@ -166,15 +164,11 @@ const B3ImportDrawer = ({
     },
     onSuccess: async (data, asDryRun) => {
       setReport(data);
+      setActiveStep(1);
       if (asDryRun) {
-        setPreviewedSignature(currentSignature);
         enqueueSnackbar("Pré-visualização gerada", { variant: "success" });
         return;
       }
-      // Applied: a fresh preview is required before applying again, and we go
-      // back to dry-run mode so the "preview first" hint doesn't show post-apply.
-      setPreviewedSignature(null);
-      setDryRun(true);
       await Promise.all([
         invalidateAssetsReportsQueries({ group_by: GroupBy.TYPE }),
         invalidateAssetsIndicatorsQueries(),
@@ -194,173 +188,220 @@ const B3ImportDrawer = ({
     },
   });
 
-  const canPreview =
+  const canLeaveFiles = hasAnyFile;
+  const canRun =
     selectedOps.length > 0 && (!needsWorkbookDt || workbookDt !== null);
-  const canApply = !dryRun && canPreview && previewedSignature === currentSignature;
-  const submitDisabled = isPending || (dryRun ? !canPreview : !canApply);
 
   return (
-    <Drawer
+    <Dialog
       open={open}
       onClose={onClose}
-      anchor="right"
+      maxWidth="lg"
+      fullWidth
+      fullScreen
       slotProps={{
         transition: { onExited: resetState },
         paper: {
           sx: {
-            width: 650,
-            maxWidth: "100vw",
             backgroundColor: getColor(Colors.neutral600),
-            boxShadow: "none",
             backgroundImage: "none",
           },
         },
       }}
     >
-      <Stack spacing={3} sx={{ p: 3 }}>
-        <Typography variant="h6">Importar arquivos da B3</Typography>
-
-        <Stack spacing={1.5}>
-          <FileDropArea onFiles={handleFiles} />
-          {SLOT_LABELS.map(({ slot, label }) => {
-            const file = files[slot];
-            return file ? (
-              <Stack key={slot} direction="row" spacing={1} alignItems="center">
-                <Typography variant="caption" sx={{ minWidth: 96 }}>
-                  {label}
-                </Typography>
-                <Typography variant="body2" noWrap sx={{ flex: 1 }}>
-                  {file.name}
-                </Typography>
-                <IconButton
-                  size="small"
-                  onClick={() => clearSlot(slot)}
-                  aria-label={`Remover ${label}`}
-                >
-                  <CloseIcon fontSize="small" />
-                </IconButton>
-              </Stack>
-            ) : null;
-          })}
-          {unrecognized.length > 0 && (
-            <Typography variant="caption" color={getColor(Colors.danger200)}>
-              Não reconhecido: {unrecognized.join(", ")}. Esperado
-              negociacao-*.xlsx, posicao-*.xlsx, movimentacao-*.xlsx
-            </Typography>
-          )}
-        </Stack>
-
-        <Divider />
-        <Stack
-          spacing={1}
+      <DialogTitle
+        sx={{ display: "flex", alignItems: "center", gap: 1, pr: 1 }}
+      >
+        Importar arquivos da B3
+        <IconButton
+          size="small"
+          aria-label="Fechar"
+          onClick={onClose}
+          sx={{ ml: "auto" }}
         >
-          <Typography variant="subtitle2">Importações</Typography>
-          <Stack
-            spacing={2}
-            direction="row"
-            alignItems="center"
-            flexWrap="wrap"
-            useFlexGap
-          >
-            {OPERATIONS.map(({ op, label }) => {
-              const enabled = isOperationEnabled(op, files);
-              return (
-                <FormControlLabel
-                  key={op}
-                  control={
-                    <Checkbox
-                      checked={selectedOps.includes(op)}
-                      disabled={!enabled}
-                      onChange={() => toggleOp(op)}
-                    />
-                  }
-                  label={label}
-                />
-              );
-            })}
-          </Stack>
-        </Stack>
+          <CloseIcon />
+        </IconButton>
+      </DialogTitle>
+      <DialogContent dividers>
+        <Stepper activeStep={activeStep} sx={{ mb: 3 }}>
+          {STEPS.map((label) => (
+            <Step key={label}>
+              <StepLabel>{label}</StepLabel>
+            </Step>
+          ))}
+        </Stepper>
 
-        {needsWorkbookDt && (
-          <LocalizationProvider
-            dateAdapter={AdapterDateFns}
-            adapterLocale={ptBR}
-          >
-            <DateTimePicker
-              label="Data da posição"
-              value={workbookDt}
-              onChange={(value) => setWorkbookDt(value)}
-              format="dd/MM/yyyy HH:mm:ss"
-              slotProps={{ textField: { variant: "standard", required: true } }}
-            />
-          </LocalizationProvider>
-        )}
-
-        <Stack
-          direction="row"
-          spacing={4}
-          alignItems="flex-start"
-          flexWrap="wrap"
-          useFlexGap
-        >
-          <FormControlLabel
-            control={
-              <Switch
-                checked={dryRun}
-                onChange={(e) => setDryRun(e.target.checked)}
-              />
-            }
-            label="Dry run (pré-visualizar)"
-          />
-          {selectedOps.includes("negociacoes") && (
-            <Stack>
-              <FormControlLabel
-                control={
-                  <Switch
-                    checked={createMissingAssets}
-                    disabled={files.posicao === null}
-                    onChange={(e) => setCreateMissingAssets(e.target.checked)}
-                  />
-                }
-                label="Criar ativos ausentes"
-              />
-              {files.posicao === null && (
-                <Typography variant="caption" color="text.secondary">
-                  Envie o arquivo de posição para habilitar
+        {activeStep === 0 && (
+          <Stack spacing={3}>
+            <Stack spacing={1.5}>
+              <FileDropArea onFiles={handleFiles} />
+              {SLOT_LABELS.map(({ slot, label }) => {
+                const file = files[slot];
+                return file ? (
+                  <Stack
+                    key={slot}
+                    direction="row"
+                    spacing={1}
+                    alignItems="center"
+                  >
+                    <Typography variant="caption" sx={{ minWidth: 96 }}>
+                      {label}
+                    </Typography>
+                    <Typography variant="body2" noWrap sx={{ flex: 1 }}>
+                      {file.name}
+                    </Typography>
+                    <IconButton
+                      size="small"
+                      onClick={() => clearSlot(slot)}
+                      aria-label={`Remover ${label}`}
+                    >
+                      <CloseIcon fontSize="small" />
+                    </IconButton>
+                  </Stack>
+                ) : null;
+              })}
+              {unrecognized.length > 0 && (
+                <Typography variant="caption" color={getColor(Colors.danger200)}>
+                  Não reconhecido: {unrecognized.join(", ")}. Esperado
+                  negociacao-*.xlsx, posicao-*.xlsx, movimentacao-*.xlsx
                 </Typography>
               )}
             </Stack>
-          )}
-        </Stack>
 
-        {!dryRun && previewedSignature !== currentSignature && (
-          <Typography variant="caption" color="warning.main">
-            Pré-visualize a configuração atual antes de aplicar.
-          </Typography>
+            <Stack spacing={1}>
+              <Typography variant="subtitle2">
+                O que você deseja importar?
+              </Typography>
+              <Stack
+                spacing={2}
+                direction="row"
+                alignItems="center"
+                flexWrap="wrap"
+                useFlexGap
+              >
+                {OPERATIONS.map(({ op, label }) => {
+                  const enabled = isOperationEnabled(op, files);
+                  return (
+                    <FormControlLabel
+                      key={op}
+                      control={
+                        <Checkbox
+                          checked={selectedOps.includes(op)}
+                          disabled={!enabled}
+                          onChange={() => toggleOp(op)}
+                        />
+                      }
+                      label={label}
+                    />
+                  );
+                })}
+              </Stack>
+            </Stack>
+
+            {(needsWorkbookDt || selectedOps.includes("negociacoes")) && (
+              <Stack
+                direction="row"
+                spacing={4}
+                alignItems="flex-start"
+                flexWrap="wrap"
+                useFlexGap
+              >
+                {needsWorkbookDt && (
+                  <LocalizationProvider
+                    dateAdapter={AdapterDateFns}
+                    adapterLocale={ptBR}
+                  >
+                    <DateTimePicker
+                      label="Data da posição"
+                      value={workbookDt}
+                      onChange={(value) => setWorkbookDt(value)}
+                      format="dd/MM/yyyy HH:mm:ss"
+                      slotProps={{
+                        textField: {
+                          variant: "standard",
+                          required: true,
+                          helperText:
+                            "Momento da posição (do nome do arquivo). Usada para decidir se o preço atual de Renda Fixa/Tesouro deve ser atualizado.",
+                        },
+                      }}
+                    />
+                  </LocalizationProvider>
+                )}
+                {selectedOps.includes("negociacoes") && (
+                  <Stack>
+                    <FormControlLabel
+                      control={
+                        <Switch
+                          checked={createMissingAssets}
+                          disabled={files.posicao === null}
+                          onChange={(e) =>
+                            setCreateMissingAssets(e.target.checked)
+                          }
+                        />
+                      }
+                      label="Criar ativos ausentes"
+                    />
+                    {files.posicao === null && (
+                      <Typography variant="caption" color="text.secondary">
+                        Envie o arquivo de posição para habilitar
+                      </Typography>
+                    )}
+                  </Stack>
+                )}
+              </Stack>
+            )}
+          </Stack>
         )}
 
-        <Stack direction="row" spacing={2} justifyContent="flex-end">
-          <Button variant="brand-text" onClick={onClose}>
-            Fechar
-          </Button>
-          <Button
-            variant="brand"
-            disabled={submitDisabled}
-            onClick={() => mutate(dryRun)}
-          >
-            {isPending ? (
-              <CircularProgress color="inherit" size={24} />
-            ) : dryRun ? (
-              "Pré-visualizar"
-            ) : (
-              "Aplicar"
-            )}
-          </Button>
-        </Stack>
+        {activeStep === 1 && report && <B3ImportReport response={report} />}
+      </DialogContent>
 
-        {report && <B3ImportReport response={report} />}
-      </Stack>
-    </Drawer>
+      <DialogActions sx={{ px: 3, py: 2 }}>
+        {activeStep === 0 && (
+          <>
+            <Button variant="brand-text" onClick={onClose}>
+              Cancelar
+            </Button>
+            <Button
+              variant="brand"
+              disabled={isPending || !canLeaveFiles || !canRun}
+              onClick={() => mutate(true)}
+            >
+              {isPending ? (
+                <CircularProgress color="inherit" size={24} />
+              ) : (
+                "Pré-visualizar"
+              )}
+            </Button>
+          </>
+        )}
+        {activeStep === 1 &&
+          (report?.dry_run ? (
+            // Showing a preview: let the user go back and tweak, or commit it.
+            <>
+              <Button variant="brand-text" onClick={() => setActiveStep(0)}>
+                Voltar
+              </Button>
+              <Button
+                variant="brand"
+                disabled={isPending}
+                onClick={() => mutate(false)}
+              >
+                {isPending ? (
+                  <CircularProgress color="inherit" size={24} />
+                ) : (
+                  "Aplicar"
+                )}
+              </Button>
+            </>
+          ) : (
+            // Already applied.
+            <Button variant="brand" onClick={onClose}>
+              Fechar
+            </Button>
+          ))}
+      </DialogActions>
+    </Dialog>
   );
 };
 

--- a/react/src/pages/private/Assets/ImportB3/index.tsx
+++ b/react/src/pages/private/Assets/ImportB3/index.tsx
@@ -43,18 +43,21 @@ const OPERATIONS: { op: B3Operation; label: string }[] = [
   { op: "negociacoes", label: "Negociações" },
   { op: "renda_fixa", label: "Renda Fixa" },
   { op: "tesouro", label: "Tesouro" },
+  { op: "proventos", label: "Proventos" },
 ];
 
 const SLOT_LABELS: { slot: B3FileSlot; label: string }[] = [
   { slot: "negociacao", label: "Negociação" },
   { slot: "posicao", label: "Posição" },
   { slot: "movimentacao", label: "Movimentação" },
+  { slot: "proventos", label: "Proventos" },
 ];
 
 const EMPTY_FILES: B3Files = {
   negociacao: null,
   posicao: null,
   movimentacao: null,
+  proventos: null,
 };
 
 const B3ImportDrawer = ({
@@ -154,6 +157,7 @@ const B3ImportDrawer = ({
       if (files.negociacao) fd.append("negociacao", files.negociacao);
       if (files.posicao) fd.append("posicao", files.posicao);
       if (files.movimentacao) fd.append("movimentacao", files.movimentacao);
+      if (files.proventos) fd.append("proventos", files.proventos);
       selectedOps.forEach((op) => fd.append("operations", op));
       fd.append("dry_run", String(asDryRun));
       fd.append("create_missing_assets", String(createMissingAssets));

--- a/react/src/pages/private/Assets/ImportB3/index.tsx
+++ b/react/src/pages/private/Assets/ImportB3/index.tsx
@@ -251,31 +251,34 @@ const B3ImportDrawer = ({
         </Stack>
 
         <Divider />
-
         <Stack
-          spacing={2}
-          direction="row"
-          alignItems="center"
-          flexWrap="wrap"
-          useFlexGap
+          spacing={1}
         >
           <Typography variant="subtitle2">Importações</Typography>
-          {OPERATIONS.map(({ op, label }) => {
-            const enabled = isOperationEnabled(op, files);
-            return (
-              <FormControlLabel
-                key={op}
-                control={
-                  <Checkbox
-                    checked={selectedOps.includes(op)}
-                    disabled={!enabled}
-                    onChange={() => toggleOp(op)}
-                  />
-                }
-                label={label}
-              />
-            );
-          })}
+          <Stack
+            spacing={2}
+            direction="row"
+            alignItems="center"
+            flexWrap="wrap"
+            useFlexGap
+          >
+            {OPERATIONS.map(({ op, label }) => {
+              const enabled = isOperationEnabled(op, files);
+              return (
+                <FormControlLabel
+                  key={op}
+                  control={
+                    <Checkbox
+                      checked={selectedOps.includes(op)}
+                      disabled={!enabled}
+                      onChange={() => toggleOp(op)}
+                    />
+                  }
+                  label={label}
+                />
+              );
+            })}
+          </Stack>
         </Stack>
 
         {needsWorkbookDt && (

--- a/react/src/pages/private/Assets/ImportB3/logic.test.ts
+++ b/react/src/pages/private/Assets/ImportB3/logic.test.ts
@@ -18,10 +18,16 @@ const assertEqual = <T>(actual: T, expected: T, message: string) => {
 const fakeFile = (name: string, lastModified = 0): File =>
   ({ name, size: name.length, lastModified }) as unknown as File;
 
-const files = (neg = false, pos = false, mov = false): B3Files => ({
+const files = (
+  neg = false,
+  pos = false,
+  mov = false,
+  prov = false,
+): B3Files => ({
   negociacao: neg ? fakeFile("negociacao.xlsx") : null,
   posicao: pos ? fakeFile("posicao-2026-04-29-12-00-00.xlsx") : null,
   movimentacao: mov ? fakeFile("movimentacao.xlsx") : null,
+  proventos: prov ? fakeFile("proventos-2026.xlsx") : null,
 });
 
 // negociacoes needs the negociacao file
@@ -47,7 +53,24 @@ assertEqual(
   "posicao classified",
 );
 assertEqual(classifyB3File("movimentacao-2026.xlsx"), "movimentacao", "movimentacao classified");
+assertEqual(
+  classifyB3File("proventos-recebidos-2026.xlsx"),
+  "proventos",
+  "proventos classified",
+);
 assertEqual(classifyB3File("relatorio.xlsx"), null, "unknown -> null");
+
+// proventos op needs the proventos file
+assertEqual(
+  isOperationEnabled("proventos", files(false, false, false, true)),
+  true,
+  "proventos enabled",
+);
+assertEqual(
+  isOperationEnabled("proventos", files(false, false, false, false)),
+  false,
+  "proventos disabled",
+);
 
 // filename parsing
 const parsed = parseWorkbookDtFromFilename("posicao-2026-04-29-12-00-00.xlsx");
@@ -100,6 +123,7 @@ const mtimeA: B3Files = {
   negociacao: null,
   posicao: fakeFile("posicao-2026-04-29-12-00-00.xlsx", 1000),
   movimentacao: fakeFile("movimentacao.xlsx", 1000),
+  proventos: null,
 };
 const mtimeB: B3Files = {
   ...mtimeA,

--- a/react/src/pages/private/Assets/ImportB3/logic.ts
+++ b/react/src/pages/private/Assets/ImportB3/logic.ts
@@ -4,6 +4,7 @@ export type B3Files = {
   negociacao: File | null;
   posicao: File | null;
   movimentacao: File | null;
+  proventos: File | null;
 };
 
 export type B3FileSlot = keyof B3Files;
@@ -15,11 +16,13 @@ export const classifyB3File = (name: string): B3FileSlot | null => {
   if (lower.startsWith("negociacao")) return "negociacao";
   if (lower.startsWith("posicao")) return "posicao";
   if (lower.startsWith("movimentacao")) return "movimentacao";
+  if (lower.startsWith("proventos")) return "proventos";
   return null;
 };
 
 export const isOperationEnabled = (op: B3Operation, files: B3Files): boolean => {
   if (op === "negociacoes") return files.negociacao !== null;
+  if (op === "proventos") return files.proventos !== null;
   // renda_fixa and tesouro both require posicao AND movimentacao
   return files.posicao !== null && files.movimentacao !== null;
 };
@@ -73,6 +76,7 @@ export const computeSignature = (
     neg: fileKey(files.negociacao),
     pos: fileKey(files.posicao),
     mov: fileKey(files.movimentacao),
+    prov: fileKey(files.proventos),
     ops: [...operations].sort(),
     dt: workbookDt ? workbookDt.toISOString() : "-",
     cma: createMissingAssets,

--- a/react/src/pages/private/Assets/ImportB3/types.ts
+++ b/react/src/pages/private/Assets/ImportB3/types.ts
@@ -1,9 +1,20 @@
-export type B3Operation = "negociacoes" | "renda_fixa" | "tesouro";
+export type B3Operation =
+  | "negociacoes"
+  | "renda_fixa"
+  | "tesouro"
+  | "proventos";
 
 export type B3Transaction = {
   action: string;
   price: string;
   quantity: string;
+  operation_date: string;
+};
+
+export type B3Income = {
+  type: string;
+  amount: string;
+  currency: string;
   operation_date: string;
 };
 
@@ -18,6 +29,7 @@ export type B3ActionEntry = {
   previous_price?: string | null;
   transactions?: B3Transaction[];
   transaction?: B3Transaction;
+  income?: B3Income;
 };
 
 export type B3OperationReport = {
@@ -26,6 +38,7 @@ export type B3OperationReport = {
   workbook_dt?: string;
   posicao_path?: string | null;
   negociacao_path?: string | null;
+  proventos_path?: string | null;
 };
 
 export type B3ImportResponse = {


### PR DESCRIPTION
Adds a 4th B3 import slice — the **Proventos Recebidos** report → `PassiveIncome`.

> **Base = `fix/b3-import-review` (#36)**, so this diff is proventos-only. Retarget to `master` once #36 merges.

## Backend
- **`proventos.py`** parser: reads the `Proventos Recebidos` sheet — code from `CODE - NAME`, `Pagamento`, `Tipo de Evento`, `Valor líquido`.
- **`import_b3_proventos`**: maps `Tipo de Evento` → `PassiveIncomeTypes` (Dividendo/JSCP/Rendimento/**Reembolso**), `event_type=credited`; asset resolved by code (unknown → `skipped`); inline validation (future-credited / asset doesn't `accept_incomes` → `error`). **Bulk**: 2 SELECTs (assets + existing credited incomes for dedup) + one `bulk_create`, then the `AssetReadModel` is upserted **once per affected asset** via the messagebus (`PassiveIncomeCreated`) since `bulk_create` skips it. `dry_run` rolls everything back (incl. the upsert).
- Wired as op `proventos` in `B3ImportSerializer` / `run_b3_import` / the view.

## Frontend
- Proventos file slot (auto-classified by `proventos-*.xlsx`), a **Proventos** checkbox, and **"Provento criado"** report rows formatted as `JCP · R$221,58 · 11/06/2026` (currency symbol + pt-BR amount + `dd/mm/yyyy`).

## Tests
- Parser on the real file (12 rows). Handler: create / dedup / skip-unknown / dry-run, **asserting `AssetReadModel.credited_incomes`** updates (221,58 apply / 0 dry-run / unchanged on dedup). Serializer + service wiring. **72 b3 tests pass**; FE `tsc` clean + `logic.test.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)