### PR TITLE
feat(ui): shared AssetCell for asset code + description columns

### DIFF
--- a/react/src/pages/private/Assets/Table/AssetCell.tsx
+++ b/react/src/pages/private/Assets/Table/AssetCell.tsx
@@ -1,0 +1,30 @@
+import type { ReactNode } from "react";
+
+import Stack from "@mui/material/Stack";
+
+const AssetCell = ({
+  code,
+  description,
+  startAdornment,
+  endAdornment,
+}: {
+  code: string;
+  description?: string;
+  startAdornment?: ReactNode;
+  endAdornment?: ReactNode;
+}) => (
+  <Stack spacing={1}>
+    <Stack direction="row" spacing={1} alignItems="center">
+      {startAdornment}
+      <span>{code}</span>
+      {endAdornment}
+    </Stack>
+    {!!description && (
+      <span style={{ marginLeft: startAdornment ? "20px" : 0 }}>
+        {description}
+      </span>
+    )}
+  </Stack>
+);
+
+export default AssetCell;

--- a/react/src/pages/private/Assets/Table/index.tsx
+++ b/react/src/pages/private/Assets/Table/index.tsx
@@ -22,6 +22,7 @@ import { defaultAssetsFilters } from "../filterConfig";
 import { getAssets } from "../api";
 import { Asset } from "../api/models";
 import { AssetCurrencyMap, LiquidityTypes, LiquidityTypesMapping } from "../consts";
+import AssetCell from "./AssetCell";
 import AssetsForm from "./AssetForm";
 import AssetUpdatePriceDrawer from "./AssetUpdatePriceDrawer";
 import { ASSETS_QUERY_KEY } from "./consts";
@@ -116,24 +117,24 @@ const Table = ({ externalFilters }: TableProps) => {
         accessorKey: "code",
         size: 50,
         Cell: ({ row: { original } }) => (
-          <Stack spacing={1}>
-            <Stack direction="row" spacing={1} alignItems="center">
+          <AssetCell
+            code={original.code}
+            description={original.description}
+            startAdornment={
               <StatusDot
                 variant={original.normalized_roi > 0 ? "success" : "danger"}
               />
-              <span>{original.code}</span>
-              {isEmergencyFundEligible(original) && (
+            }
+            endAdornment={
+              isEmergencyFundEligible(original) && (
                 <Tooltip title="Reserva de emergência">
                   <SavingsOutlinedIcon
                     sx={{ fontSize: 16, color: getColor(Colors.brand) }}
                   />
                 </Tooltip>
-              )}
-            </Stack>
-            {!!original.description && (
-              <span style={{ marginLeft: "20px" }}>{original.description}</span>
-            )}
-          </Stack>
+              )
+            }
+          />
         ),
       },
       {

--- a/react/src/pages/private/Incomes/Table/index.tsx
+++ b/react/src/pages/private/Incomes/Table/index.tsx
@@ -19,6 +19,7 @@ import {
 import { Colors, getColor } from "../../../../design-system";
 import useTable from "../../../../hooks/useTable";
 import { AssetCurrencyMap } from "../../Assets/consts";
+import AssetCell from "../../Assets/Table/AssetCell";
 import { getIncomes } from "../api";
 import CreateOrEditIncomeDrawer from "../components/CreateOrEditIncomeDrawer";
 import { useOnFormSuccess as useInvalidateIncomesQueries } from "../components/CreateOrEditIncomeDrawer/hooks";
@@ -111,10 +112,15 @@ const Table = ({ externalFilters }: TableProps) => {
   const columns = useMemo<Column<Income>[]>(
     () => [
       {
-        header: "Código ativo",
+        header: "Ativo",
         acessorKey: "asset.code",
         size: 50,
-        Cell: ({ row: { original } }) => original.asset.code,
+        Cell: ({ row: { original } }) => (
+          <AssetCell
+            code={original.asset.code}
+            description={original.asset.description}
+          />
+        ),
       },
       {
         header: "Categoria ativo",

--- a/react/src/pages/private/Transactions/Table/index.tsx
+++ b/react/src/pages/private/Transactions/Table/index.tsx
@@ -27,6 +27,7 @@ import EditTransactionDrawer from "./EditTransactionDrawer";
 import { useInvalidateTransactionsQueries } from "./hooks";
 
 import { AssetCurrencyMap } from "../../Assets/consts";
+import AssetCell from "../../Assets/Table/AssetCell";
 import { TransactionsContext } from "../context";
 import { customEndOfMonth } from "../../utils";
 import TopToolBar from "./ToopToolBar";
@@ -99,10 +100,15 @@ const Table = ({ externalFilters }: TableProps) => {
   const columns = useMemo<Column<Transaction>[]>(
     () => [
       {
-        header: "Código ativo",
+        header: "Ativo",
         acessorKey: "asset.code",
         size: 50,
-        Cell: ({ row: { original } }) => original.asset.code,
+        Cell: ({ row: { original } }) => (
+          <AssetCell
+            code={original.asset.code}
+            description={original.asset.description}
+          />
+        ),
       },
       {
         header: "Categoria ativo",


### PR DESCRIPTION
## Summary
- Extract the code/description cell from the assets table into a reusable `AssetCell` component with optional start/end adornments (ROI status dot, emergency-fund icon)
- Reuse it in the transactions and incomes tables: first column renamed from "Código ativo" to "Ativo" and now shows the asset description under the code
- No visual change on `/assets`; `/assets/transactions` and `/assets/incomes` gain the description line

## Test plan
- `npx tsc --noEmit` clean
- Manually check the three tables render code + description as before/expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vsch9NyyE6Z3g7SmfTfC9y