### PR TITLE
Fix B3 import request timeout

### DIFF
--- a/react/src/api/instances.js
+++ b/react/src/api/instances.js
@@ -5,9 +5,11 @@ import { apiProvider } from "./methods";
 
 import { AccessTokenStr, BaseApiUrl, RefreshTokenStr } from "../consts";
 
+const DEFAULT_API_TIMEOUT_MS = 30_000;
+
 let publicAxios = axios.create({
   baseURL: BaseApiUrl,
-  timeout: 5000,
+  timeout: DEFAULT_API_TIMEOUT_MS,
 });
 
 const getAuthHeaders = () => {
@@ -17,7 +19,7 @@ const getAuthHeaders = () => {
 
 let privateAxios = axios.create({
   baseURL: BaseApiUrl,
-  timeout: 5000,
+  timeout: DEFAULT_API_TIMEOUT_MS,
   headers: getAuthHeaders(),
 });
 

--- a/react/src/pages/private/Assets/api/index.ts
+++ b/react/src/pages/private/Assets/api/index.ts
@@ -15,12 +15,17 @@ import {
 } from "./models";
 
 const RESOURCE = "assets";
+const B3_IMPORT_TIMEOUT_MS = 120_000;
 
 // Pass FormData directly; axios derives the multipart boundary itself.
 export const importB3 = async (
   formData: FormData,
 ): Promise<B3ImportResponse> =>
-  (await apiProvider.post(`${RESOURCE}/b3_import`, formData)).data;
+  (
+    await apiProvider.post(`${RESOURCE}/b3_import`, formData, {
+      timeout: B3_IMPORT_TIMEOUT_MS,
+    })
+  ).data;
 
 type AssetsIndicatorsResponse = {
   ROI: number;


### PR DESCRIPTION
## Summary
- increase the shared Axios timeout from 5 seconds to 30 seconds
- give B3 imports an endpoint-specific 120-second timeout
- leave backend import and parser behavior unchanged

## Production issue
B3 imports take longer than 5 seconds on Render, so Axios aborts before the successful response arrives and Gunicorn logs EPIPE.

## Verification
- corepack yarn build
- git diff --check

Tests were not added or run, per request.