### PR TITLE
Fix B3 fixed-income movement code parsing

### DIFF
--- a/django/variable_income_assets/integrations/b3/movimentacao.py
+++ b/django/variable_income_assets/integrations/b3/movimentacao.py
@@ -75,8 +75,8 @@ def _to_required_decimal(value, *, column: str, row_index: int) -> Decimal:
 
 
 def _split_produto(produto: str) -> tuple[B3FixedIncomeKind, str] | None:
-    parts = produto.split(" - ", 1)
-    if len(parts) != 2:
+    parts = produto.split(" - ", 2)
+    if len(parts) < 2:
         return None
     prefix, code = parts[0].strip().upper(), parts[1].strip()
     try:


### PR DESCRIPTION
## Summary
- parse the fixed-income code from the second `Produto` segment
- ignore the optional issuer suffix emitted by B3 exports

## Production impact
B3 exports values such as `CDB - CDB7256UUUB - NU FINANCEIRA ...`. The previous parser included the issuer in the code, so the movement did not match the position and raised `ativo não cadastrado e sem linha de movimentação`.

## Verification
- Parsed the supplied full-period workbook: 9 fixed-income movements, including exact code `CDB7256UUUB`
- Existing movement parser suite: 9 passed
- `git diff --check` passed